### PR TITLE
Bug 1757553: Escalating external ip 1.17.0 beta.2

### DIFF
--- a/pkg/authorization/scope/converter.go
+++ b/pkg/authorization/scope/converter.go
@@ -24,6 +24,7 @@ const (
 	kubeAuthorizationGroupName      = "authorization.k8s.io"
 	openshiftAuthorizationGroupName = "authorization.openshift.io"
 	imageGroupName                  = "image.openshift.io"
+	networkGroupName                = "network.openshift.io"
 	oauthGroupName                  = "oauth.openshift.io"
 	projectGroupName                = "project.openshift.io"
 	userGroupName                   = "user.openshift.io"
@@ -266,6 +267,8 @@ var escalatingScopeResources = []schema.GroupResource{
 	{Group: openshiftAuthorizationGroupName, Resource: "rolebindings"},
 	{Group: openshiftAuthorizationGroupName, Resource: "clusterroles"},
 	{Group: openshiftAuthorizationGroupName, Resource: "clusterrolebindings"},
+	// used in Service admission to create a service with external IP outside the allowed range
+	{Group: networkGroupName, Resource: "service"},
 
 	{Group: legacyGroupName, Resource: "imagestreams/secrets"},
 	{Group: legacyGroupName, Resource: "oauthauthorizetokens"},


### PR DESCRIPTION
This is used in admitting Services with external IPs that reach
outside the allowed IP range.