### PR TITLE
Bug 1779694: fix the externalIP scope escalation

### DIFF
--- a/pkg/authorization/scope/converter.go
+++ b/pkg/authorization/scope/converter.go
@@ -268,7 +268,7 @@ var escalatingScopeResources = []schema.GroupResource{
 	{Group: openshiftAuthorizationGroupName, Resource: "clusterroles"},
 	{Group: openshiftAuthorizationGroupName, Resource: "clusterrolebindings"},
 	// used in Service admission to create a service with external IP outside the allowed range
-	{Group: networkGroupName, Resource: "service"},
+	{Group: networkGroupName, Resource: "service/externalips"},
 
 	{Group: legacyGroupName, Resource: "imagestreams/secrets"},
 	{Group: legacyGroupName, Resource: "oauthauthorizetokens"},


### PR DESCRIPTION
The externalIP admission actually uses the externalips subresource
so the current escalating rules cleanup would ignore that.