### PR TITLE
[release-4.3] Bug 1793587: sccadmission plugin incorrectly reports "no SecurityContextConstraints found in xxx"

### DIFF
--- a/pkg/securitycontextconstraints/sccadmission/admission.go
+++ b/pkg/securitycontextconstraints/sccadmission/admission.go
@@ -6,15 +6,18 @@ import (
 	"io"
 	"sort"
 	"strings"
+	"time"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/admission/initializer"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 	coreapi "k8s.io/kubernetes/pkg/apis/core"
 	kapihelper "k8s.io/kubernetes/pkg/apis/core/helper"
@@ -22,9 +25,10 @@ import (
 	"k8s.io/kubernetes/pkg/serviceaccount"
 
 	securityv1 "github.com/openshift/api/security/v1"
-	"github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/sccmatching"
 	securityv1informer "github.com/openshift/client-go/security/informers/externalversions/security/v1"
 	securityv1listers "github.com/openshift/client-go/security/listers/security/v1"
+
+	"github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/sccmatching"
 )
 
 const PluginName = "security.openshift.io/SecurityContextConstraint"
@@ -40,6 +44,7 @@ type constraint struct {
 	*admission.Handler
 	client     kubernetes.Interface
 	sccLister  securityv1listers.SecurityContextConstraintsLister
+	sccSynced  cache.InformerSynced
 	authorizer authorizer.Authorizer
 }
 
@@ -128,6 +133,13 @@ func (c *constraint) Validate(ctx context.Context, a admission.Attributes, _ adm
 func (c *constraint) computeSecurityContext(a admission.Attributes, pod *coreapi.Pod, specMutationAllowed bool, validatedSCCHint string) (*coreapi.Pod, string, field.ErrorList, error) {
 	// get all constraints that are usable by the user
 	klog.V(4).Infof("getting security context constraints for pod %s (generate: %s) in namespace %s with user info %v", pod.Name, pod.GenerateName, a.GetNamespace(), a.GetUserInfo())
+
+	err := wait.PollImmediate(1*time.Second, 10*time.Second, func() (bool, error) {
+		return c.sccSynced(), nil
+	})
+	if err != nil {
+		return nil, "", nil, admission.NewForbidden(a, fmt.Errorf("securitycontextconstraints.security.openshift.io cache is not synchronized"))
+	}
 
 	constraints, err := sccmatching.NewDefaultSCCMatcher(c.sccLister, nil).FindApplicableSCCs(a.GetNamespace())
 	if err != nil {
@@ -253,6 +265,7 @@ func shouldIgnore(a admission.Attributes) (bool, error) {
 // SetSecurityInformers implements WantsSecurityInformer interface for constraint.
 func (c *constraint) SetSecurityInformers(informers securityv1informer.SecurityContextConstraintsInformer) {
 	c.sccLister = informers.Lister()
+	c.sccSynced = informers.Informer().HasSynced
 }
 
 func (c *constraint) SetExternalKubeClientSet(client kubernetes.Interface) {
@@ -267,6 +280,9 @@ func (c *constraint) SetAuthorizer(authorizer authorizer.Authorizer) {
 func (c *constraint) ValidateInitialization() error {
 	if c.sccLister == nil {
 		return fmt.Errorf("%s requires an sccLister", PluginName)
+	}
+	if c.sccSynced == nil {
+		return fmt.Errorf("%s requires an sccSynced", PluginName)
 	}
 	if c.client == nil {
 		return fmt.Errorf("%s requires a client", PluginName)

--- a/pkg/securitycontextconstraints/sccadmission/admission_test.go
+++ b/pkg/securitycontextconstraints/sccadmission/admission_test.go
@@ -53,6 +53,7 @@ func newTestAdmission(lister securityv1listers.SecurityContextConstraintsLister,
 		Handler:    admission.NewHandler(admission.Create),
 		client:     kclient,
 		sccLister:  lister,
+		sccSynced:  func() bool { return true },
 		authorizer: authorizer,
 	}
 }

--- a/pkg/securitycontextconstraints/sccadmission/scc_exec_test.go
+++ b/pkg/securitycontextconstraints/sccadmission/scc_exec_test.go
@@ -98,6 +98,7 @@ func TestExecAdmit(t *testing.T) {
 		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 		cache := securityv1listers.NewSecurityContextConstraintsLister(indexer)
 		p.constraintAdmission.sccLister = cache
+		p.constraintAdmission.sccSynced = func() bool { return true }
 		p.SetExternalKubeClientSet(tc)
 
 		attrs := admission.NewAttributesRecord(nil, nil, coreapi.Kind("Pod").WithVersion("version"), "namespace", "pod-name", coreapi.Resource(v.resource).WithVersion("version"), v.subresource, v.operation, nil, false, &user.DefaultInfo{})


### PR DESCRIPTION
Cherry pick of https://github.com/openshift/apiserver-library-go/pull/20.
[Bug 1793587](https://bugzilla.redhat.com/show_bug.cgi?id=1793587) - sccadmission plugin incorrectly reports "no SecurityContextConstraints found in xxx"