### PR TITLE
Fix field paths in SCC validation error messages

### DIFF
--- a/pkg/securitycontextconstraints/capabilities/mustrunas.go
+++ b/pkg/securitycontextconstraints/capabilities/mustrunas.go
@@ -67,7 +67,7 @@ func (s *defaultCapabilities) Generate(pod *api.Pod, container *api.Container) (
 }
 
 // Validate ensures that the specified values fall within the range of the strategy.
-func (s *defaultCapabilities) Validate(pod *api.Pod, container *api.Container, capabilities *api.Capabilities) field.ErrorList {
+func (s *defaultCapabilities) Validate(fldPath *field.Path, pod *api.Pod, container *api.Container, capabilities *api.Capabilities) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if capabilities == nil {
@@ -80,7 +80,7 @@ func (s *defaultCapabilities) Validate(pod *api.Pod, container *api.Container, c
 
 		// container has no requested caps but we have required caps.  We should have something in
 		// at least the drops on the container.
-		allErrs = append(allErrs, field.Invalid(field.NewPath("capabilities"), capabilities,
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("capabilities"), capabilities,
 			"required capabilities are not set on the securityContext"))
 		return allErrs
 	}
@@ -98,7 +98,7 @@ func (s *defaultCapabilities) Validate(pod *api.Pod, container *api.Container, c
 	for _, cap := range capabilities.Add {
 		sCap := string(cap)
 		if !defaultAdd.Has(sCap) && !allowedAdd.Has(sCap) {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("capabilities", "add"), sCap, "capability may not be added"))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("capabilities", "add"), sCap, "capability may not be added"))
 		}
 	}
 
@@ -108,7 +108,7 @@ func (s *defaultCapabilities) Validate(pod *api.Pod, container *api.Container, c
 	for _, requiredDrop := range s.requiredDropCapabilities {
 		sDrop := string(requiredDrop)
 		if !containerDrops.Has(sDrop) {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("capabilities", "drop"), capabilities.Drop,
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("capabilities", "drop"), capabilities.Drop,
 				fmt.Sprintf("%s is required to be dropped but was not found", sDrop)))
 		}
 	}

--- a/pkg/securitycontextconstraints/capabilities/mustrunas_test.go
+++ b/pkg/securitycontextconstraints/capabilities/mustrunas_test.go
@@ -327,7 +327,7 @@ func TestValidateAdds(t *testing.T) {
 			t.Errorf("%s failed: %v", k, err)
 			continue
 		}
-		errs := strategy.Validate(nil, nil, v.containerCaps)
+		errs := strategy.Validate(nil, nil, nil, v.containerCaps)
 		if v.shouldPass && len(errs) > 0 {
 			t.Errorf("%s should have passed but had errors %v", k, errs)
 			continue
@@ -384,7 +384,7 @@ func TestValidateDrops(t *testing.T) {
 			t.Errorf("%s failed: %v", k, err)
 			continue
 		}
-		errs := strategy.Validate(nil, nil, v.containerCaps)
+		errs := strategy.Validate(nil, nil, nil, v.containerCaps)
 		if v.shouldPass && len(errs) > 0 {
 			t.Errorf("%s should have passed but had errors %v", k, errs)
 			continue

--- a/pkg/securitycontextconstraints/capabilities/types.go
+++ b/pkg/securitycontextconstraints/capabilities/types.go
@@ -10,5 +10,5 @@ type CapabilitiesSecurityContextConstraintsStrategy interface {
 	// Generate creates the capabilities based on policy rules.
 	Generate(pod *api.Pod, container *api.Container) (*api.Capabilities, error)
 	// Validate ensures that the specified values fall within the range of the strategy.
-	Validate(pod *api.Pod, container *api.Container, capabilities *api.Capabilities) field.ErrorList
+	Validate(fldPath *field.Path, pod *api.Pod, container *api.Container, capabilities *api.Capabilities) field.ErrorList
 }

--- a/pkg/securitycontextconstraints/group/mustrunas.go
+++ b/pkg/securitycontextconstraints/group/mustrunas.go
@@ -45,17 +45,17 @@ func (s *mustRunAs) GenerateSingle(_ *api.Pod) (*int64, error) {
 // Validate ensures that the specified values fall within the range of the strategy.
 // Groups are passed in here to allow this strategy to support multiple group fields (fsgroup and
 // supplemental groups).
-func (s *mustRunAs) Validate(_ *api.Pod, groups []int64) field.ErrorList {
+func (s *mustRunAs) Validate(fldPath *field.Path, _ *api.Pod, groups []int64) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if len(groups) == 0 && len(s.ranges) > 0 {
-		allErrs = append(allErrs, field.Invalid(field.NewPath(s.field), groups, "unable to validate empty groups against required ranges"))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child(s.field), groups, "unable to validate empty groups against required ranges"))
 	}
 
 	for _, group := range groups {
 		if !s.isGroupValid(group) {
 			detail := fmt.Sprintf("%d is not an allowed group", group)
-			allErrs = append(allErrs, field.Invalid(field.NewPath(s.field), groups, detail))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child(s.field), groups, detail))
 		}
 	}
 

--- a/pkg/securitycontextconstraints/group/mustrunas_test.go
+++ b/pkg/securitycontextconstraints/group/mustrunas_test.go
@@ -152,7 +152,7 @@ func TestValidate(t *testing.T) {
 		if err != nil {
 			t.Errorf("error creating strategy for %s: %v", k, err)
 		}
-		errs := s.Validate(nil, v.groups)
+		errs := s.Validate(nil, nil, v.groups)
 		if v.pass && len(errs) > 0 {
 			t.Errorf("unexpected errors for %s: %v", k, errs)
 		}

--- a/pkg/securitycontextconstraints/group/runasany.go
+++ b/pkg/securitycontextconstraints/group/runasany.go
@@ -27,7 +27,7 @@ func (s *runAsAny) GenerateSingle(_ *api.Pod) (*int64, error) {
 }
 
 // Validate ensures that the specified values fall within the range of the strategy.
-func (s *runAsAny) Validate(_ *api.Pod, groups []int64) field.ErrorList {
+func (s *runAsAny) Validate(fldPath *field.Path, _ *api.Pod, groups []int64) field.ErrorList {
 	return field.ErrorList{}
 
 }

--- a/pkg/securitycontextconstraints/group/runasany_test.go
+++ b/pkg/securitycontextconstraints/group/runasany_test.go
@@ -37,7 +37,7 @@ func TestRunAsAnyValidte(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error initializing NewRunAsAny %v", err)
 	}
-	errs := s.Validate(nil, nil)
+	errs := s.Validate(nil, nil, nil)
 	if len(errs) != 0 {
 		t.Errorf("unexpected errors: %v", errs)
 	}

--- a/pkg/securitycontextconstraints/group/types.go
+++ b/pkg/securitycontextconstraints/group/types.go
@@ -15,5 +15,5 @@ type GroupSecurityContextConstraintsStrategy interface {
 	// value to return if configured with multiple ranges.  This is used for FSGroup.
 	GenerateSingle(pod *api.Pod) (*int64, error)
 	// Validate ensures that the specified values fall within the range of the strategy.
-	Validate(pod *api.Pod, groups []int64) field.ErrorList
+	Validate(fldPath *field.Path, pod *api.Pod, groups []int64) field.ErrorList
 }

--- a/pkg/securitycontextconstraints/sccmatching/provider.go
+++ b/pkg/securitycontextconstraints/sccmatching/provider.go
@@ -293,7 +293,7 @@ func (s *simpleProvider) ValidateContainerSecurityContext(pod *api.Pod, containe
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("privileged"), *privileged, "Privileged containers are not allowed"))
 	}
 
-	allErrs = append(allErrs, s.capabilitiesStrategy.Validate(pod, container, sc.Capabilities())...)
+	allErrs = append(allErrs, s.capabilitiesStrategy.Validate(fldPath, pod, container, sc.Capabilities())...)
 
 	if !s.scc.AllowHostNetwork && podSC.HostNetwork() {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("hostNetwork"), podSC.HostNetwork(), "Host network is not allowed to be used"))

--- a/pkg/securitycontextconstraints/sccmatching/provider.go
+++ b/pkg/securitycontextconstraints/sccmatching/provider.go
@@ -284,7 +284,7 @@ func (s *simpleProvider) ValidateContainerSecurityContext(pod *api.Pod, containe
 	podSC := securitycontext.NewPodSecurityContextAccessor(pod.Spec.SecurityContext)
 	sc := securitycontext.NewEffectiveContainerSecurityContextAccessor(podSC, securitycontext.NewContainerSecurityContextMutator(container.SecurityContext))
 
-	allErrs = append(allErrs, s.runAsUserStrategy.Validate(fldPath.Child("securityContext"), pod, container, sc.RunAsNonRoot(), sc.RunAsUser())...)
+	allErrs = append(allErrs, s.runAsUserStrategy.Validate(fldPath, pod, container, sc.RunAsNonRoot(), sc.RunAsUser())...)
 	allErrs = append(allErrs, s.seLinuxStrategy.Validate(fldPath.Child("seLinuxOptions"), pod, container, sc.SELinuxOptions())...)
 	allErrs = append(allErrs, s.seccompStrategy.ValidateContainer(pod, container)...)
 

--- a/pkg/securitycontextconstraints/sccmatching/provider.go
+++ b/pkg/securitycontextconstraints/sccmatching/provider.go
@@ -215,8 +215,8 @@ func (s *simpleProvider) ValidatePodSecurityContext(pod *api.Pod, fldPath *field
 	if fsGroup := sc.FSGroup(); fsGroup != nil {
 		fsGroups = append(fsGroups, *fsGroup)
 	}
-	allErrs = append(allErrs, s.fsGroupStrategy.Validate(pod, fsGroups)...)
-	allErrs = append(allErrs, s.supplementalGroupStrategy.Validate(pod, sc.SupplementalGroups())...)
+	allErrs = append(allErrs, s.fsGroupStrategy.Validate(fldPath, pod, fsGroups)...)
+	allErrs = append(allErrs, s.supplementalGroupStrategy.Validate(fldPath, pod, sc.SupplementalGroups())...)
 	allErrs = append(allErrs, s.seccompStrategy.ValidatePod(pod)...)
 
 	allErrs = append(allErrs, s.seLinuxStrategy.Validate(fldPath.Child("seLinuxOptions"), pod, nil, sc.SELinuxOptions())...)


### PR DESCRIPTION
This fixes three issues in the error messages produced by the SCC validation:
- "securityContext" field is repeated in runAsUser validation message
- capabilities validation doesn't indicate the container the error applies to
- fsGroup/supplementalGroups doesn't indicate the full path (e.g. spec.securityContext.fsGroup)