### PR TITLE
scc-admission: add audit annotations with reason

### DIFF
--- a/pkg/securitycontextconstraints/sccmatching/provider.go
+++ b/pkg/securitycontextconstraints/sccmatching/provider.go
@@ -355,6 +355,10 @@ func (s *simpleProvider) hasHostPort(container *api.Container, fldPath *field.Pa
 	return allErrs
 }
 
+func (s *simpleProvider) GetSCC() *securityv1.SecurityContextConstraints {
+	return s.scc
+}
+
 // Get the name of the SCC that this provider was initialized with.
 func (s *simpleProvider) GetSCCName() string {
 	return s.scc.Name

--- a/pkg/securitycontextconstraints/sccmatching/types.go
+++ b/pkg/securitycontextconstraints/sccmatching/types.go
@@ -1,6 +1,7 @@
 package sccmatching
 
 import (
+	securityv1 "github.com/openshift/api/security/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	api "k8s.io/kubernetes/pkg/apis/core"
 )
@@ -16,6 +17,8 @@ type SecurityContextConstraintsProvider interface {
 	ValidatePodSecurityContext(pod *api.Pod, fldPath *field.Path) field.ErrorList
 	// Ensure a container's SecurityContext is in compliance with the given constraints
 	ValidateContainerSecurityContext(pod *api.Pod, container *api.Container, fldPath *field.Path) field.ErrorList
+	// Get the SCC that this provider was initialized with.
+	GetSCC() *securityv1.SecurityContextConstraints
 	// Get the name of the SCC that this provider was initialized with.
 	GetSCCName() string
 	// Get the users associated to the SCC this provider was initialized with

--- a/pkg/securitycontextconstraints/util/sort/bypriority.go
+++ b/pkg/securitycontextconstraints/util/sort/bypriority.go
@@ -13,6 +13,10 @@ func (s ByPriority) Len() int {
 }
 func (s ByPriority) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s ByPriority) Less(i, j int) bool {
+	ret, _ := s.LessWithReason(i, j)
+	return ret
+}
+func (s ByPriority) LessWithReason(i, j int) (bool, string) {
 	iSCC := s[i]
 	jSCC := s[j]
 
@@ -21,11 +25,11 @@ func (s ByPriority) Less(i, j int) bool {
 
 	// a higher priority is considered "less" so that it moves to the front of the line
 	if iSCCPriority > jSCCPriority {
-		return true
+		return true, "has higher priority"
 	}
 
 	if iSCCPriority < jSCCPriority {
-		return false
+		return false, "has lower priority"
 	}
 
 	// priorities are equal, let's try point values
@@ -35,15 +39,15 @@ func (s ByPriority) Less(i, j int) bool {
 	// a lower restriction score is considered "less" so that it moves to the front of the line
 	// (the greater the score, the more lax the SCC is)
 	if iRestrictionScore < jRestrictionScore {
-		return true
+		return true, moreRestrictiveReason(iRestrictionScore, jRestrictionScore)
 	}
 
 	if iRestrictionScore > jRestrictionScore {
-		return false
+		return false, moreRestrictiveReason(jRestrictionScore, iRestrictionScore)
 	}
 
 	// they are still equal, sort by name
-	return iSCC.Name < jSCC.Name
+	return iSCC.Name < jSCC.Name, "ordered by name"
 }
 
 func getPriority(scc *securityv1.SecurityContextConstraints) int {


### PR DESCRIPTION
- `securityserviceconstraints.admission.k8s.io/denied: restrictive,privileged`
- `securitycontextconstraints.admission.k8s.io/too-restrictive-foo: <validation-errors>`, e.g.:
```
   "securitycontextconstraints.admission.k8s.io/too-restrictive-anyuid": "[spec.volumes[6]: Invalid value: \"hostPath\": hostPath volumes are not allowed to be used, spec.initContainers[0].securityContext.privileged: Invalid value: true: Privileged containers are not allowed, spec.containers[0].securityContext.privileged: Invalid value: true: Privileged containers are not allowed]",
```
- `securitycontextconstraints.admission.k8s.io/reason: "foo" is most restrictive, not denied, and chosen over "bar" because "foo" forbids host networking`.