### PR TITLE
Bug 1996646: pkg/securitycontextconstraints: fix points groups

### DIFF
--- a/pkg/securitycontextconstraints/sccmatching/matcher.go
+++ b/pkg/securitycontextconstraints/sccmatching/matcher.go
@@ -38,7 +38,8 @@ func NewDefaultSCCMatcher(c securityv1listers.SecurityContextConstraintsLister, 
 }
 
 // FindApplicableSCCs implements SCCMatcher interface
-// It finds all SCCs that the subjects in the `users` argument may use.
+// It finds all SCCs that the subjects in the `users` argument may use for the given `namespace`.
+// If `users` is omitted, `namespace` is ignored.
 // The returned SCCs are sorted by priority.
 func (d *defaultSCCMatcher) FindApplicableSCCs(ctx context.Context, namespace string, users ...user.Info) ([]*securityv1.SecurityContextConstraints, error) {
 	var matchedConstraints []*securityv1.SecurityContextConstraints


### PR DESCRIPTION
To generate a reason message we rely on the fact that point groups are not overflowing.
However, the current numbering does not respect the fact that runAs* points are counted twice,
once for RunAsUser and once for SELinuxContext constraints.

This fixes it by shifting the numbers to account for selinux runAs* point scores.

/cc @deads2k @mfojtik @sttts 