### PR TITLE
Bug 2000216: Image policy should mutate DeploymentConfigs and StatefulSets

### DIFF
--- a/pkg/admission/imagepolicy/apis/imagepolicy/v1/defaults.go
+++ b/pkg/admission/imagepolicy/apis/imagepolicy/v1/defaults.go
@@ -25,6 +25,7 @@ func SetDefaults_ImagePolicyConfig(obj *ImagePolicyConfig) {
 		obj.ResolutionRules = []ImageResolutionPolicyRule{
 			{TargetResource: metav1.GroupResource{Group: "", Resource: "pods"}, LocalNames: true},
 			{TargetResource: metav1.GroupResource{Group: "", Resource: "replicationcontrollers"}, LocalNames: true},
+			{TargetResource: metav1.GroupResource{Group: "apps.openshift.io", Resource: "deploymentconfigs"}, LocalNames: true},
 			{TargetResource: metav1.GroupResource{Group: "apps", Resource: "daemonsets"}, LocalNames: true},
 			{TargetResource: metav1.GroupResource{Group: "apps", Resource: "deployments"}, LocalNames: true},
 			{TargetResource: metav1.GroupResource{Group: "apps", Resource: "statefulsets"}, LocalNames: true},

--- a/pkg/admission/imagepolicy/imagepolicy.go
+++ b/pkg/admission/imagepolicy/imagepolicy.go
@@ -488,8 +488,6 @@ var skipImageRewriteOnUpdate = map[metav1.GroupResource]struct{}{
 	{Group: "batch", Resource: "jobs"}: {},
 	// Build specs are immutable, they cannot be updated.
 	{Group: "build.openshift.io", Resource: "builds"}: {},
-	// TODO: remove when statefulsets allow spec.template updates in 3.7
-	{Group: "apps", Resource: "statefulsets"}: {},
 }
 
 // RewriteImagePullSpec applies to implicit rewrite attributes and local resources as well as if the policy requires it.

--- a/pkg/admission/imagepolicy/imagepolicy_test.go
+++ b/pkg/admission/imagepolicy/imagepolicy_test.go
@@ -1053,21 +1053,6 @@ func TestResolutionConfig(t *testing.T) {
 			resolve:  true,
 			rewrite:  false,
 		},
-		// resource match skips on statefulset update
-		// TODO: remove in 3.7
-		{
-			attrs: rules.ImagePolicyAttributes{LocalRewrite: true},
-			config: &imagepolicy.ImagePolicyConfig{
-				ResolveImages: imagepolicy.DoNotAttempt,
-				ResolutionRules: []imagepolicy.ImageResolutionPolicyRule{
-					{LocalNames: true, TargetResource: metav1.GroupResource{Group: "apps", Resource: "statefulsets"}},
-				},
-			},
-			resource: metav1.GroupResource{Group: "apps", Resource: "statefulsets"},
-			update:   true,
-			resolve:  true,
-			rewrite:  false,
-		},
 	}
 
 	for i, test := range testCases {


### PR DESCRIPTION
The image policy admission plugin should know about DeploymentConfigs and should mutate StatefulSets not only on creation, but also on update.