### PR TITLE
Bug 2023342: scc admission: add ephemeralContainers to admission consideration

### DIFF
--- a/pkg/securitycontextconstraints/sccmatching/matcher.go
+++ b/pkg/securitycontextconstraints/sccmatching/matcher.go
@@ -123,24 +123,31 @@ func AssignSecurityContext(provider SecurityContextConstraintsProvider, pod *kap
 	errs = append(errs, provider.ValidatePodSecurityContext(pod, fldPath.Child("spec", "securityContext"))...)
 
 	for i := range pod.Spec.InitContainers {
-		sc, err := provider.CreateContainerSecurityContext(pod, &pod.Spec.InitContainers[i])
-		if err != nil {
-			errs = append(errs, field.Invalid(field.NewPath("spec", "initContainers").Index(i).Child("securityContext"), "", err.Error()))
-			continue
-		}
-		pod.Spec.InitContainers[i].SecurityContext = sc
-		errs = append(errs, provider.ValidateContainerSecurityContext(pod, &pod.Spec.InitContainers[i], field.NewPath("spec", "initContainers").Index(i).Child("securityContext"))...)
+		errs = append(errs, assignContainerSecurityContext(provider, pod, &pod.Spec.InitContainers[i], field.NewPath("spec", "initContainers").Index(i).Child("securityContext"))...)
+	}
+	for i := range pod.Spec.EphemeralContainers {
+		errs = append(errs, assignContainerSecurityContext(provider, pod, (*kapi.Container)(&pod.Spec.EphemeralContainers[i].EphemeralContainerCommon), field.NewPath("spec", "ephemeralContainers").Index(i).Child("securityContext"))...)
+	}
+	for i := range pod.Spec.Containers {
+		errs = append(errs, assignContainerSecurityContext(provider, pod, &pod.Spec.Containers[i], field.NewPath("spec", "containers").Index(i).Child("securityContext"))...)
 	}
 
-	for i := range pod.Spec.Containers {
-		sc, err := provider.CreateContainerSecurityContext(pod, &pod.Spec.Containers[i])
-		if err != nil {
-			errs = append(errs, field.Invalid(field.NewPath("spec", "containers").Index(i).Child("securityContext"), "", err.Error()))
-			continue
-		}
-		pod.Spec.Containers[i].SecurityContext = sc
-		errs = append(errs, provider.ValidateContainerSecurityContext(pod, &pod.Spec.Containers[i], field.NewPath("spec", "containers").Index(i).Child("securityContext"))...)
+	if len(errs) > 0 {
+		return errs
 	}
+
+	return nil
+}
+
+func assignContainerSecurityContext(provider SecurityContextConstraintsProvider, pod *kapi.Pod, container *kapi.Container, fldPath *field.Path) field.ErrorList {
+	errs := field.ErrorList{}
+	sc, err := provider.CreateContainerSecurityContext(pod, container)
+	if err != nil {
+		errs = append(errs, field.Invalid(fldPath, "", err.Error()))
+		return errs
+	}
+	container.SecurityContext = sc
+	errs = append(errs, provider.ValidateContainerSecurityContext(pod, container, fldPath)...)
 
 	if len(errs) > 0 {
 		return errs


### PR DESCRIPTION
kube 1.23 turns the ephemeralContainers feature "on" by default,
add this podSpec field to SCC admission to prevent privilege escalation.

/assign @s-urbaniak 
/cc @deads2k 

---

edit: the feature gets turned on by default in
https://github.com/kubernetes/kubernetes/pull/105405/files#diff-71e3b98f9a6bbf5b8421e26a7ba0c079f397cd8d49abacdad943c66a4f44f03dR795