### PR TITLE
scc, scope authorizer: add the auth team ownership

### DIFF
--- a/pkg/authorization/OWNERS
+++ b/pkg/authorization/OWNERS
@@ -1,0 +1,7 @@
+reviewers:
+  - s-urbaniak
+  - slaskawi
+  - ibihim
+  - stlaz
+approvers:
+  - stlaz

--- a/pkg/securitycontextconstraints/OWNERS
+++ b/pkg/securitycontextconstraints/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+  - s-urbaniak
+  - slaskawi
+  - ibihim
+  - stlaz
+approvers:
+  - stlaz
+  - s-urbaniak


### PR DESCRIPTION
The auth team owns the SCCs and the scope authorizer, they should be at least reviewers there.

/cc @s-urbaniak 
/cc @deads2k 