### PR TITLE
Bug 2093440: include pluginName in caches not syncd error

### DIFF
--- a/pkg/admission/quota/clusterresourcequota/admission.go
+++ b/pkg/admission/quota/clusterresourcequota/admission.go
@@ -3,6 +3,7 @@ package clusterresourcequota
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"sort"
 	"sync"
@@ -102,8 +103,8 @@ func (q *clusterQuotaAdmission) Validate(ctx context.Context, a admission.Attrib
 		return nil
 	}
 
-	if !q.waitForSyncedStore(time.After(timeToWaitForCacheSync)) {
-		return admission.NewForbidden(a, errors.New("caches not synchronized"))
+	if !q.waitForSyncedStore(time.After(timeToWaitForCacheSync)) {		
+		return admission.NewForbidden(a, fmt.Errorf("%s-%s: caches not synchronized", accessor.GetNamespace(), accessor.GetName()))
 	}
 
 	q.init.Do(func() {

--- a/pkg/admission/quota/clusterresourcequota/admission.go
+++ b/pkg/admission/quota/clusterresourcequota/admission.go
@@ -32,8 +32,12 @@ import (
 	"github.com/openshift/library-go/pkg/quota/clusterquotamapping"
 )
 
+const (
+	pluginName = "quota.openshift.io/ClusterResourceQuota"
+)
+
 func Register(plugins *admission.Plugins) {
-	plugins.Register("quota.openshift.io/ClusterResourceQuota",
+	plugins.Register(pluginName,
 		func(config io.Reader) (admission.Interface, error) {
 			return NewClusterResourceQuota()
 		})
@@ -103,8 +107,8 @@ func (q *clusterQuotaAdmission) Validate(ctx context.Context, a admission.Attrib
 		return nil
 	}
 
-	if !q.waitForSyncedStore(time.After(timeToWaitForCacheSync)) {		
-		return admission.NewForbidden(a, fmt.Errorf("%s-%s: caches not synchronized", accessor.GetNamespace(), accessor.GetName()))
+	if !q.waitForSyncedStore(time.After(timeToWaitForCacheSync)) {
+		return admission.NewForbidden(a, fmt.Errorf("%s: caches not synchronized", pluginName))
 	}
 
 	q.init.Do(func() {


### PR DESCRIPTION
Include the accessor namespace and name in the error when Validate fails due to 'caches not synchronized'