### PR TITLE
Bug 2086519: scc: set container nonroot=true if the pod/container RunAsUser is non-zero

### DIFF
--- a/pkg/securitycontextconstraints/sccadmission/admission_test.go
+++ b/pkg/securitycontextconstraints/sccadmission/admission_test.go
@@ -310,6 +310,7 @@ func TestAdmitSuccess(t *testing.T) {
 
 	seLinuxLevelFromNamespace := namespace.Annotations[securityv1.MCSAnnotation]
 
+	trueVal := true
 	testCases := map[string]struct {
 		pod                 *coreapi.Pod
 		expectedPodSC       *coreapi.PodSecurityContext
@@ -318,27 +319,27 @@ func TestAdmitSuccess(t *testing.T) {
 		"specifyUIDInRange": {
 			pod:                 specifyUIDInRange,
 			expectedPodSC:       podSC(seLinuxLevelFromNamespace, defaultGroup, defaultGroup),
-			expectedContainerSC: containerSC(nil, goodUID),
+			expectedContainerSC: containerSC(nil, goodUID, &trueVal),
 		},
 		"specifyLabels": {
 			pod:                 specifyLabels,
 			expectedPodSC:       podSC(seLinuxLevelFromNamespace, defaultGroup, defaultGroup),
-			expectedContainerSC: containerSC(&seLinuxLevelFromNamespace, 1),
+			expectedContainerSC: containerSC(&seLinuxLevelFromNamespace, 1, &trueVal),
 		},
 		"specifyFSGroup": {
 			pod:                 specifyFSGroupInRange,
 			expectedPodSC:       podSC(seLinuxLevelFromNamespace, goodFSGroup, defaultGroup),
-			expectedContainerSC: containerSC(nil, 1),
+			expectedContainerSC: containerSC(nil, 1, &trueVal),
 		},
 		"specifySupGroup": {
 			pod:                 specifySupGroup,
 			expectedPodSC:       podSC(seLinuxLevelFromNamespace, defaultGroup, 3),
-			expectedContainerSC: containerSC(nil, 1),
+			expectedContainerSC: containerSC(nil, 1, &trueVal),
 		},
 		"specifyPodLevelSELinuxLevel": {
 			pod:                 specifyPodLevelSELinux,
 			expectedPodSC:       podSC(seLinuxLevelFromNamespace, defaultGroup, defaultGroup),
-			expectedContainerSC: containerSC(nil, 1),
+			expectedContainerSC: containerSC(nil, 1, &trueVal),
 		},
 	}
 
@@ -1344,9 +1345,10 @@ func linuxPod() *coreapi.Pod {
 	}
 }
 
-func containerSC(seLinuxLevel *string, uid int64) *coreapi.SecurityContext {
+func containerSC(seLinuxLevel *string, uid int64, runAsNonRoot *bool) *coreapi.SecurityContext {
 	sc := &coreapi.SecurityContext{
-		RunAsUser: &uid,
+		RunAsUser:    &uid,
+		RunAsNonRoot: runAsNonRoot,
 	}
 	if seLinuxLevel != nil {
 		sc.SELinuxOptions = &coreapi.SELinuxOptions{

--- a/pkg/securitycontextconstraints/sccmatching/provider.go
+++ b/pkg/securitycontextconstraints/sccmatching/provider.go
@@ -170,9 +170,24 @@ func (s *simpleProvider) CreateContainerSecurityContext(pod *api.Pod, container 
 	// if we're using the non-root strategy set the marker that this container should not be
 	// run as root which will signal to the kubelet to do a final check either on the runAsUser
 	// or, if runAsUser is not set, the image
-	if sc.RunAsNonRoot() == nil && sc.RunAsUser() == nil && s.scc.RunAsUser.Type == securityv1.RunAsUserStrategyMustRunAsNonRoot {
-		nonRoot := true
-		sc.SetRunAsNonRoot(&nonRoot)
+	// Alternatively, also set the RunAsNonRoot to true in case the UID value is non-nil and non-zero
+	// to more easily satisfy the requirements of upstream PodSecurity admission "restricted" profile
+	// which currently requires all containers to have runAsNonRoot set to true, or to have this set
+	// in the whole pod's security context
+	if sc.RunAsNonRoot() == nil {
+		nonRoot := false
+		switch runAsUser := sc.RunAsUser(); {
+		case runAsUser == nil:
+			if s.scc.RunAsUser.Type == securityv1.RunAsUserStrategyMustRunAsNonRoot {
+				nonRoot = true
+			}
+		case *runAsUser > 0:
+			nonRoot = true
+		}
+
+		if nonRoot {
+			sc.SetRunAsNonRoot(&nonRoot)
+		}
 	}
 
 	caps, err := s.capabilitiesStrategy.Generate(pod, container)


### PR DESCRIPTION
PodSecurity admission requires the non-zero flag to be set no matter
the container/pod UID.

/assign @deads2k 