### PR TITLE
Add SCC history field to track former SCC assignments 

### DIFF
--- a/vendor/github.com/openshift/api/security/v1/consts.go
+++ b/vendor/github.com/openshift/api/security/v1/consts.go
@@ -7,4 +7,5 @@ const (
 	SupplementalGroupsAnnotation = "openshift.io/sa.scc.supplemental-groups"
 	MCSAnnotation                = "openshift.io/sa.scc.mcs"
 	ValidatedSCCAnnotation       = "openshift.io/scc"
+	SCCHistory                   = "openshift.io/scc-history"
 )


### PR DESCRIPTION
Whenever a mutating webhook modifies a pod, the SCC admission plugin
will be run a second time. Therefore, during the admission stage, a pod
can have been assigned to and mutated by several distinct SCCs. Think of
the pod being assigned the restricted SCC before webhooks run and the
restricted SCC mutating the runAsUser field, a webhook modifying the
pod, and then finally the privileged SCC being assigned to the pod.
In order to signal to administrators that a pod was assigned to and
possibly mutated by multiple SCCs during its creation phase, add a new
SCC history field which will store all former SCC assignments.

Goes hand in hand with https://github.com/openshift/api/pull/1408