### PR TITLE
Always try to respect SCC Hints

### DIFF
--- a/pkg/securitycontextconstraints/sccadmission/admission_test.go
+++ b/pkg/securitycontextconstraints/sccadmission/admission_test.go
@@ -936,6 +936,28 @@ func TestAdmitWithPrioritizedSCC(t *testing.T) {
 	matchingPriorityAndScoreSCCOnePod := goodPod()
 	matchingPriorityAndScoreSCCOnePod.Spec.Containers[0].SecurityContext.RunAsUser = &uidSix
 	testSCCAdmission(matchingPriorityAndScoreSCCOnePod, plugin, matchingPriorityAndScoreSCCOne.Name, "match matchingPriorityAndScoreSCCOne by setting RunAsUser to 6", t)
+
+	hintPod1 := goodPod()
+	hintPod1.Annotations = map[string]string{
+		securityv1.SCCHint: matchingPrioritySCCOne.Name,
+	}
+	testSCCAdmission(hintPod1, plugin, matchingPrioritySCCOne.Name, "match SCC matchingPriorityAndScoreSCCOne", t)
+
+	hintPod2 := goodPod()
+	hintPod2.Annotations = map[string]string{
+		securityv1.SCCHint: matchingPrioritySCCOne.Name,
+	}
+	hintPod2.Spec.Containers[0].SecurityContext.RunAsUser = &uidFive
+	testSCCAdmission(hintPod2, plugin, matchingPrioritySCCOne.Name, "match SCC matchingPrioritySCCOne even when "+
+		"RunAsUser is set to to 5", t)
+
+	hintPod3 := goodPod()
+	hintPod3.Annotations = map[string]string{
+		securityv1.SCCHint: matchingPrioritySCCOne.Name,
+	}
+	hintPod3.Spec.Containers[0].SecurityContext.RunAsUser = &uidSix
+	testSCCAdmission(hintPod3, plugin, matchingPriorityAndScoreSCCOne.Name, "match SCC matchingPriorityAndScoreSCCOne "+
+		"when RunAsUser is set to 6 (ignore SCCHint)", t)
 }
 
 func TestAdmitSeccomp(t *testing.T) {

--- a/vendor/github.com/openshift/api/security/v1/consts.go
+++ b/vendor/github.com/openshift/api/security/v1/consts.go
@@ -7,4 +7,5 @@ const (
 	SupplementalGroupsAnnotation = "openshift.io/sa.scc.supplemental-groups"
 	MCSAnnotation                = "openshift.io/sa.scc.mcs"
 	ValidatedSCCAnnotation       = "openshift.io/scc"
+	SCCHint                      = "openshift.io/scc-hint"
 )


### PR DESCRIPTION
During the SCC mutation stage, respect pod annotation "scc-hint"
whenever possible.

This changes SCC priorization to:
1. SCC matching "scc-hint" annotation first.
2. If "scc-hint" is empty or does not match, sort by priority, nil is
       considered a 0 priority.
3. If priorities are equal, the SCCs will be sorted from most
       restrictive to least restrictive.f
4. If both priorities and restrictions are equal the SCCs will be
       sorted by name.

Less intrusive, alternative implementation to https://github.com/openshift/apiserver-library-go/pull/90 with a minimal change (excluding the variable rename it's just 4 lines of new logic) and IMO it gets the job done without too much risk of breaking existing logic.

Here's how it works, in an example setup:
* anyuid2 is a copy of anyuid with priority 11
* check possible candidates for the cluster-node-tunint-operator:
~~~
[akaris@linux kubernetes (test-scc-hint)]$ oc get pods cluster-node-tuning-operator-8f8bcd8b7-qqzqc -o yaml | oc policy scc-review -f -
RESOURCE                                           SERVICE ACCOUNT                ALLOWED BY         
Pod/cluster-node-tuning-operator-8f8bcd8b7-qqzqc   cluster-node-tuning-operator   anyuid2            
Pod/cluster-node-tuning-operator-8f8bcd8b7-qqzqc   cluster-node-tuning-operator   anyuid             
Pod/cluster-node-tuning-operator-8f8bcd8b7-qqzqc   cluster-node-tuning-operator   nonroot-v2         
Pod/cluster-node-tuning-operator-8f8bcd8b7-qqzqc   cluster-node-tuning-operator   nonroot            
Pod/cluster-node-tuning-operator-8f8bcd8b7-qqzqc   cluster-node-tuning-operator   hostmount-anyuid   
Pod/cluster-node-tuning-operator-8f8bcd8b7-qqzqc   cluster-node-tuning-operator   node-exporter      
Pod/cluster-node-tuning-operator-8f8bcd8b7-qqzqc   cluster-node-tuning-operator   privileged
~~~

Default:
~~~
[akaris@linux kubernetes (test-scc-hint)]$ oc get deployment cluster-node-tuning-operator -o jsonpath='{.spec.template.metadata.annotations}' | jq '.'
{
  "target.workload.openshift.io/management": "{\"effect\": \"PreferredDuringScheduling\"}"
}
[akaris@linux kubernetes (test-scc-hint)]$ oc get pods -o yaml -o jsonpath='{.items[0].metadata.annotations}' | jq '.' | grep sc
  "openshift.io/scc": "anyuid2"
[akaris@linux kubernetes (test-scc-hint)]$ oc get pods -o yaml -o jsonpath='{.items[0].metadata.annotations}' | jq '.' | grep scc
  "openshift.io/scc": "anyuid2"
~~~

Provide a non-existing SCC:
~~~
[akaris@linux kubernetes (test-scc-hint)]$ oc get deployment cluster-node-tuning-operator -o jsonpath='{.spec.template.metadata.annotations}' | jq '.'
{
  "openshift.io/scc-hint": "anyuiddd",
  "target.workload.openshift.io/management": "{\"effect\": \"PreferredDuringScheduling\"}"
}
[akaris@linux kubernetes (test-scc-hint)]$ oc get pods -o yaml -o jsonpath='{.items[0].metadata.annotations}' | jq '.' | grep scc
  "openshift.io/scc": "anyuid2",
  "openshift.io/scc-hint": "anyuiddd"
~~~

Provide an existing and matching SCC but which is too restrictive:
~~~
[akaris@linux kubernetes (test-scc-hint)]$ oc get pods -o yaml -o jsonpath='{.items[0].metadata.annotations}' | jq '.' | grep scc
  "openshift.io/scc": "anyuid2",
  "openshift.io/scc-hint": "nonroot"
~~~

Provide an existing and matching SCC which can be used by the pod:
~~~
[akaris@linux kubernetes (test-scc-hint)]$ oc get deployment cluster-node-tuning-operator -o jsonpath='{.spec.template.metadata.annotations}' | jq '.'
{
  "openshift.io/scc-hint": "privileged",
  "target.workload.openshift.io/management": "{\"effect\": \"PreferredDuringScheduling\"}"
}
[akaris@linux kubernetes (test-scc-hint)]$ oc get pods -o yaml -o jsonpath='{.items[0].metadata.annotations}' | jq '.' | grep scc
  "openshift.io/scc": "privileged",
  "openshift.io/scc-hint": "privileged"
~~~

~~~
[akaris@linux kubernetes (test-scc-hint)]$ oc get deployment cluster-node-tuning-operator -o jsonpath='{.spec.template.metadata.annotations}' | jq '.'
{
  "openshift.io/scc-hint": "anyuid",
  "target.workload.openshift.io/management": "{\"effect\": \"PreferredDuringScheduling\"}"
}
[akaris@linux kubernetes (test-scc-hint)]$ oc get pods -o yaml -o jsonpath='{.items[0].metadata.annotations}' | jq '.' | grep scc
  "openshift.io/scc": "anyuid",
  "openshift.io/scc-hint": "anyuid"
~~~