### PR TITLE
pkg/securitycontextconstraints/sccadmission: simplify retrieving SCCs

### DIFF
--- a/pkg/securitycontextconstraints/sccadmission/admission.go
+++ b/pkg/securitycontextconstraints/sccadmission/admission.go
@@ -206,20 +206,14 @@ func (c *constraint) computeSecurityContext(ctx context.Context, a admission.Att
 		return nil, "", nil, admission.NewForbidden(a, fmt.Errorf("securitycontextconstraints.security.openshift.io required check failed oddly"))
 	}
 
-	constraints, err := sccmatching.NewDefaultSCCMatcher(c.sccLister, nil).FindApplicableSCCs(ctx, a.GetNamespace())
+	constraints, err := c.sccLister.List(labels.Everything())
 	if err != nil {
 		return nil, "", nil, admission.NewForbidden(a, err)
 	}
 	if len(constraints) == 0 {
-		sccs, err := c.sccLister.List(labels.Everything())
-		if err != nil {
-			return nil, "", nil, admission.NewForbidden(a, err)
-		}
-		if len(sccs) == 0 {
-			return nil, "", nil, admission.NewForbidden(a, fmt.Errorf("no SecurityContextConstraints found in cluster"))
-		}
-		return nil, "", nil, admission.NewForbidden(a, fmt.Errorf("no SecurityContextConstraints found in namespace %s", a.GetNamespace()))
+		return nil, "", nil, admission.NewForbidden(a, fmt.Errorf("no SecurityContextConstraints found in cluster"))
 	}
+	sort.Sort(sccsort.ByPriority(constraints))
 
 	// If mutation is not allowed and validatedSCCHint is provided, check the validated policy first.
 	// Keep the order the same for everything else


### PR DESCRIPTION
This is scavanging a small portion of https://github.com/openshift/apiserver-library-go/pull/107 where `FindApplicableSCCs` is invoked with the requested namespace but without a user. Hence, the current logic returns all SCCs. This indirection makes the current code hard to read.

This PR suggests to simplify it and list all SCCs instead which is the same logic.

/cc @stlaz 