### PR TITLE
[4.10] handle ephemeral containers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,5 +44,5 @@ replace (
 	k8s.io/mount-utils => k8s.io/mount-utils v0.23.0
 	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.23.0
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.23.0
-
+	vbom.ml/util => github.com/fvbommel/util v0.0.0-20180919145318-efcd4e0f9787
 )

--- a/go.sum
+++ b/go.sum
@@ -209,6 +209,7 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fvbommel/sortorder v1.0.1/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui720w+kxuqRs0=
+github.com/fvbommel/util v0.0.0-20180919145318-efcd4e0f9787/go.mod h1:AlRx4sdoz6EdWGYPMeunQWYf46cKnq7J4iVvLgyb5cY=
 github.com/getkin/kin-openapi v0.76.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -1254,4 +1255,3 @@ sigs.k8s.io/structured-merge-diff/v4 v4.2.0/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZa
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
-vbom.ml/util v0.0.0-20180919145318-efcd4e0f9787/go.mod h1:so/NYdZXCz+E3ZpW0uAoCj6uzU2+8OWDFv/HxUSs7kI=

--- a/pkg/securitycontextconstraints/sccadmission/admission.go
+++ b/pkg/securitycontextconstraints/sccadmission/admission.go
@@ -376,11 +376,23 @@ loop:
 	return allowedPod, allowingProvider.GetSCCName(), validationErrs, nil
 }
 
+var ignoredSubresources = sets.NewString(
+	"exec",
+	"attach",
+	"binding",
+	"eviction",
+	"log",
+	"portforward",
+	"proxy",
+	"status",
+)
+
 func shouldIgnore(a admission.Attributes) (bool, error) {
 	if a.GetResource().GroupResource() != coreapi.Resource("pods") {
 		return true, nil
 	}
-	if len(a.GetSubresource()) != 0 {
+
+	if subresource := a.GetSubresource(); len(subresource) != 0 && ignoredSubresources.Has(subresource) {
 		return true, nil
 	}
 

--- a/pkg/securitycontextconstraints/sccadmission/admission.go
+++ b/pkg/securitycontextconstraints/sccadmission/admission.go
@@ -70,13 +70,14 @@ func NewConstraint() *constraint {
 // Admit determines if the pod should be admitted based on the requested security context
 // and the available SCCs.
 //
-// 1.  Find SCCs for the user.
-// 2.  Find SCCs for the SA.  If there is an error retrieving SA SCCs it is not fatal.
-// 3.  Remove duplicates between the user/SA SCCs.
-// 4.  Create the providers, includes setting pre-allocated values if necessary.
-// 5.  Try to generate and validate an SCC with providers.  If we find one then admit the pod
+//  1. Find SCCs for the user.
+//  2. Find SCCs for the SA.  If there is an error retrieving SA SCCs it is not fatal.
+//  3. Remove duplicates between the user/SA SCCs.
+//  4. Create the providers, includes setting pre-allocated values if necessary.
+//  5. Try to generate and validate an SCC with providers.  If we find one then admit the pod
 //     with the validated SCC.  If we don't find any reject the pod and give all errors from the
 //     failed attempts.
+//
 // On updates, the BeforeUpdate of the pod strategy only zeroes out the status.  That means that
 // any change that claims the pod is no longer privileged will be removed.  That should hold until
 // we get a true old/new set of objects in.
@@ -90,8 +91,9 @@ func (c *constraint) Admit(ctx context.Context, a admission.Attributes, _ admiss
 
 	// TODO(liggitt): allow spec mutation during initializing updates?
 	specMutationAllowed := a.GetOperation() == admission.Create
+	ephemeralContainersMutationAllowed := specMutationAllowed || (a.GetOperation() == admission.Update && a.GetSubresource() == "ephemeralcontainers")
 
-	allowedPod, sccName, validationErrs, err := c.computeSecurityContext(ctx, a, pod, specMutationAllowed, "")
+	allowedPod, sccName, validationErrs, err := c.computeSecurityContext(ctx, a, pod, specMutationAllowed, ephemeralContainersMutationAllowed, "")
 	if err != nil {
 		return admission.NewForbidden(a, err)
 	}
@@ -121,7 +123,7 @@ func (c *constraint) Validate(ctx context.Context, a admission.Attributes, _ adm
 	pod := a.GetObject().(*coreapi.Pod)
 
 	// compute the context. Mutation is not allowed. ValidatedSCCAnnotation is used as a hint to gain same speed-up.
-	allowedPod, _, validationErrs, err := c.computeSecurityContext(ctx, a, pod, false, pod.ObjectMeta.Annotations[securityv1.ValidatedSCCAnnotation])
+	allowedPod, _, validationErrs, err := c.computeSecurityContext(ctx, a, pod, false, false, pod.ObjectMeta.Annotations[securityv1.ValidatedSCCAnnotation])
 	if err != nil {
 		return admission.NewForbidden(a, err)
 	}
@@ -165,7 +167,13 @@ func requireStandardSCCs(sccs []*securityv1.SecurityContextConstraints, err erro
 	return fmt.Errorf("securitycontextconstraints.security.openshift.io cache is missing %v", strings.Join(missingSCCs.List(), ", "))
 }
 
-func (c *constraint) computeSecurityContext(ctx context.Context, a admission.Attributes, pod *coreapi.Pod, specMutationAllowed bool, validatedSCCHint string) (*coreapi.Pod, string, field.ErrorList, error) {
+func (c *constraint) computeSecurityContext(
+	ctx context.Context,
+	a admission.Attributes,
+	pod *coreapi.Pod,
+	specMutationAllowed, ephemeralContainersMutationAllowed bool,
+	validatedSCCHint string,
+) (*coreapi.Pod, string, field.ErrorList, error) {
 	// get all constraints that are usable by the user
 	klog.V(4).Infof("getting security context constraints for pod %s (generate: %s) in namespace %s with user info %v", pod.Name, pod.GenerateName, a.GetNamespace(), a.GetUserInfo())
 
@@ -212,6 +220,8 @@ func (c *constraint) computeSecurityContext(ctx context.Context, a admission.Att
 	// If mutation is not allowed and validatedSCCHint is provided, check the validated policy first.
 	// Keep the order the same for everything else
 	sort.SliceStable(constraints, func(i, j int) bool {
+		// disregard the ephemeral containers here, the rest of the pod should still
+		// not get mutated and so we are primarily interested in the SCC that matched previously
 		if !specMutationAllowed {
 			if constraints[i].Name == validatedSCCHint {
 				return true
@@ -300,6 +310,18 @@ loop:
 			allowingProvider = provider
 			klog.V(5).Infof("pod %s (generate: %s) validated against provider %s with mutation", pod.Name, pod.GenerateName, provider.GetSCCName())
 			break loop
+		case ephemeralContainersMutationAllowed:
+			podCopyCopy := podCopy.DeepCopy()
+			// check if, possibly, only the ephemeral containers were mutated
+			podCopyCopy.Spec.EphemeralContainers = pod.Spec.EphemeralContainers
+			if apiequality.Semantic.DeepEqual(pod, podCopyCopy) {
+				allowedPod = podCopy
+				allowingProvider = provider
+				klog.V(5).Infof("pod %s (generate: %s) validated against provider %s with ephemeralContainers mutation", pod.Name, pod.GenerateName, provider.GetSCCName())
+				break loop
+			}
+			klog.V(5).Infof("pod %s (generate: %s) validated against provider %s, but required pod mutation outside ephemeralContainers, skipping", pod.Name, pod.GenerateName, provider.GetSCCName())
+			failures[provider.GetSCCName()] = "failures final validation after mutating admission"
 		case apiequality.Semantic.DeepEqual(pod, podCopy):
 			// if we don't allow mutation, only use the validated pod if it didn't require any spec changes
 			allowedPod = podCopy
@@ -308,7 +330,7 @@ loop:
 			break loop
 		default:
 			klog.V(5).Infof("pod %s (generate: %s) validated against provider %s, but required mutation, skipping", pod.Name, pod.GenerateName, provider.GetSCCName())
-			failures[provider.GetSCCName()] = fmt.Sprintf("failures final validation after mutating admission")
+			failures[provider.GetSCCName()] = "failures final validation after mutating admission"
 		}
 	}
 

--- a/pkg/securitycontextconstraints/sccadmission/admission_test.go
+++ b/pkg/securitycontextconstraints/sccadmission/admission_test.go
@@ -1110,6 +1110,10 @@ func TestAdmitPreferNonmutatingWhenPossible(t *testing.T) {
 	nonMutatingSCC := laxSCC()
 	nonMutatingSCC.Name = "non-mutating-scc"
 
+	restrictiveNonMutatingSCC := laxSCC()
+	restrictiveNonMutatingSCC.Name = "restrictive-non-mutating-scc"
+	restrictiveNonMutatingSCC.AllowHostPorts = false
+
 	simplePod := goodPod()
 	simplePod.Spec.Containers[0].Name = "simple-pod"
 	simplePod.Spec.Containers[0].Image = "test-image:0.1"
@@ -1117,28 +1121,72 @@ func TestAdmitPreferNonmutatingWhenPossible(t *testing.T) {
 	modifiedPod := simplePod.DeepCopy()
 	modifiedPod.Spec.Containers[0].Image = "test-image:0.2"
 
+	modifiedByEphemeralContainers := simplePod.DeepCopy()
+	modifiedByEphemeralContainers.Spec.EphemeralContainers = []coreapi.EphemeralContainer{
+		{
+			EphemeralContainerCommon: coreapi.EphemeralContainerCommon{
+				SecurityContext: &coreapi.SecurityContext{},
+			},
+		},
+	}
+
+	modifiedByHostPortEphemeralContainers := modifiedByEphemeralContainers.DeepCopy()
+	modifiedByHostPortEphemeralContainers.Spec.EphemeralContainers[0].Ports = []coreapi.ContainerPort{
+		{
+			HostPort: 80,
+		},
+	}
+
+	mutatingProvider, err := sccmatching.NewSimpleProvider(mutatingSCC)
+	if err != nil {
+		t.Fatalf("failed to create a mutating provider: %v", err)
+	}
+	mutatedPod := simplePod.DeepCopy()
+	mutatedPod.Spec.SecurityContext, mutatedPod.Annotations, err = mutatingProvider.CreatePodSecurityContext(mutatedPod)
+	if err != nil {
+		t.Fatalf("failed to mutate the pod: %v", err)
+	}
+
+	mutatedPod.Spec.Containers[0].SecurityContext, err = mutatingProvider.CreateContainerSecurityContext(
+		mutatedPod,
+		&mutatedPod.Spec.Containers[0],
+	)
+	if err != nil {
+		t.Fatalf("failed to mutate the container: %v", err)
+	}
+
+	mutatedPodModifiedByEpehemeralContainers := mutatedPod.DeepCopy()
+	mutatedPodModifiedByEpehemeralContainers.Spec.EphemeralContainers = []coreapi.EphemeralContainer{
+		{
+			EphemeralContainerCommon: coreapi.EphemeralContainerCommon{
+				SecurityContext: &coreapi.SecurityContext{},
+			},
+		},
+	}
+
 	tests := map[string]struct {
 		oldPod      *coreapi.Pod
 		newPod      *coreapi.Pod
 		operation   admission.Operation
+		subresource string
 		sccs        []*securityv1.SecurityContextConstraints
 		shouldPass  bool
 		expectedSCC string
 	}{
-		"creation: the first SCC (even if it mutates) should be used": {
+		"creation: most restrictive SCC (even if it mutates) should be used": {
 			newPod:      simplePod.DeepCopy(),
 			operation:   admission.Create,
-			sccs:        []*securityv1.SecurityContextConstraints{mutatingSCC, nonMutatingSCC},
+			sccs:        []*securityv1.SecurityContextConstraints{restrictiveNonMutatingSCC, mutatingSCC, nonMutatingSCC},
 			shouldPass:  true,
 			expectedSCC: mutatingSCC.Name,
 		},
-		"updating: the first non-mutating SCC should be used": {
+		"updating: most restrictive non-mutating SCC should be used": {
 			oldPod:      simplePod.DeepCopy(),
 			newPod:      modifiedPod.DeepCopy(),
 			operation:   admission.Update,
-			sccs:        []*securityv1.SecurityContextConstraints{mutatingSCC, nonMutatingSCC},
+			sccs:        []*securityv1.SecurityContextConstraints{mutatingSCC, nonMutatingSCC, restrictiveNonMutatingSCC},
 			shouldPass:  true,
-			expectedSCC: nonMutatingSCC.Name,
+			expectedSCC: restrictiveNonMutatingSCC.Name,
 		},
 		"updating: a pod should be rejected when there are only mutating SCCs": {
 			oldPod:     simplePod.DeepCopy(),
@@ -1146,6 +1194,47 @@ func TestAdmitPreferNonmutatingWhenPossible(t *testing.T) {
 			operation:  admission.Update,
 			sccs:       []*securityv1.SecurityContextConstraints{mutatingSCC},
 			shouldPass: false,
+		},
+		"updating ephemeral containers: the first non-mutating SCC should be used": {
+			oldPod:      simplePod.DeepCopy(),
+			newPod:      modifiedByEphemeralContainers.DeepCopy(),
+			operation:   admission.Update,
+			subresource: "ephemeralcontainers",
+			sccs:        []*securityv1.SecurityContextConstraints{mutatingSCC, nonMutatingSCC},
+			shouldPass:  true,
+			expectedSCC: nonMutatingSCC.Name,
+		},
+		"updating ephemeral containers: only an SCC that also mutates the rest of the pod is available": {
+			oldPod:      simplePod.DeepCopy(),
+			newPod:      modifiedByEphemeralContainers.DeepCopy(),
+			operation:   admission.Update,
+			subresource: "ephemeralcontainers",
+			sccs:        []*securityv1.SecurityContextConstraints{mutatingSCC},
+			shouldPass:  false,
+		},
+		"updating ephemeral containers: only an SCC that would mutate the new container is available": {
+			oldPod:      mutatedPod.DeepCopy(),
+			newPod:      mutatedPodModifiedByEpehemeralContainers.DeepCopy(),
+			operation:   admission.Update,
+			subresource: "ephemeralcontainers",
+			sccs:        []*securityv1.SecurityContextConstraints{mutatingSCC},
+			shouldPass:  true,
+			expectedSCC: mutatingSCC.Name,
+		},
+		"updating ephemeral containers without subresource: only an SCC that would mutate the new container is available": {
+			oldPod:     mutatedPod.DeepCopy(),
+			newPod:     mutatedPodModifiedByEpehemeralContainers.DeepCopy(),
+			operation:  admission.Update,
+			sccs:       []*securityv1.SecurityContextConstraints{mutatingSCC},
+			shouldPass: false,
+		},
+		"updating ephemeral containers: only a non-mutating non-matching SCC": {
+			oldPod:      simplePod.DeepCopy(),
+			newPod:      modifiedByHostPortEphemeralContainers.DeepCopy(),
+			operation:   admission.Update,
+			subresource: "ephemeralcontainers",
+			sccs:        []*securityv1.SecurityContextConstraints{restrictiveNonMutatingSCC},
+			shouldPass:  false,
 		},
 	}
 
@@ -1158,7 +1247,7 @@ func TestAdmitPreferNonmutatingWhenPossible(t *testing.T) {
 		testAuthorizer := &sccTestAuthorizer{t: t}
 		plugin := newTestAdmission(lister, tc, testAuthorizer)
 
-		attrs := admission.NewAttributesRecord(testCase.newPod, testCase.oldPod, coreapi.Kind("Pod").WithVersion("version"), testCase.newPod.Namespace, testCase.newPod.Name, coreapi.Resource("pods").WithVersion("version"), "", testCase.operation, nil, false, &user.DefaultInfo{})
+		attrs := admission.NewAttributesRecord(testCase.newPod, testCase.oldPod, coreapi.Kind("Pod").WithVersion("version"), testCase.newPod.Namespace, testCase.newPod.Name, coreapi.Resource("pods").WithVersion("version"), testCase.subresource, testCase.operation, nil, false, &user.DefaultInfo{})
 		err := plugin.(admission.MutationInterface).Admit(context.TODO(), attrs, nil)
 
 		if testCase.shouldPass {

--- a/pkg/securitycontextconstraints/sccadmission/admission_test.go
+++ b/pkg/securitycontextconstraints/sccadmission/admission_test.go
@@ -2,6 +2,7 @@ package sccadmission
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"sort"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
@@ -23,6 +25,7 @@ import (
 	"github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/sccmatching"
 	sccsort "github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/util/sort"
 	securityv1listers "github.com/openshift/client-go/security/listers/security/v1"
+	podhelpers "k8s.io/kubernetes/pkg/apis/core/pods"
 )
 
 // createSAForTest Build and Initializes a ServiceAccount for tests
@@ -99,7 +102,7 @@ func TestAdmitCaps(t *testing.T) {
 	allowAllInAllowed.AllowedCapabilities = []corev1.Capability{securityv1.AllowAllCapabilities}
 
 	tc := map[string]struct {
-		pod                  *coreapi.Pod
+		caps                 *coreapi.Capabilities
 		sccs                 []*securityv1.SecurityContextConstraints
 		shouldPass           bool
 		expectedCapabilities *coreapi.Capabilities
@@ -107,41 +110,40 @@ func TestAdmitCaps(t *testing.T) {
 		// UC 1: if an SCC does not define allowed or required caps then a pod requesting a cap
 		// should be rejected.
 		"should reject cap add when not allowed or required": {
-			pod:        createPodWithCaps(&coreapi.Capabilities{Add: []coreapi.Capability{"foo"}}),
+			caps:       &coreapi.Capabilities{Add: []coreapi.Capability{"foo"}},
 			sccs:       []*securityv1.SecurityContextConstraints{restricted},
 			shouldPass: false,
 		},
 		// UC 2: if an SCC allows a cap in the allowed field it should accept the pod request
 		// to add the cap.
 		"should accept cap add when in allowed": {
-			pod:        createPodWithCaps(&coreapi.Capabilities{Add: []coreapi.Capability{"foo"}}),
+			caps:       &coreapi.Capabilities{Add: []coreapi.Capability{"foo"}},
 			sccs:       []*securityv1.SecurityContextConstraints{restricted, allowsFooInAllowed},
 			shouldPass: true,
 		},
 		// UC 3: if an SCC requires a cap then it should accept the pod request
 		// to add the cap.
 		"should accept cap add when in required": {
-			pod:        createPodWithCaps(&coreapi.Capabilities{Add: []coreapi.Capability{"foo"}}),
+			caps:       &coreapi.Capabilities{Add: []coreapi.Capability{"foo"}},
 			sccs:       []*securityv1.SecurityContextConstraints{restricted, allowsFooInRequired},
 			shouldPass: true,
 		},
 		// UC 4: if an SCC requires a cap to be dropped then it should fail both
 		// in the verification of adds and verification of drops
 		"should reject cap add when requested cap is required to be dropped": {
-			pod:        createPodWithCaps(&coreapi.Capabilities{Add: []coreapi.Capability{"foo"}}),
+			caps:       &coreapi.Capabilities{Add: []coreapi.Capability{"foo"}},
 			sccs:       []*securityv1.SecurityContextConstraints{restricted, requiresFooToBeDropped},
 			shouldPass: false,
 		},
 		// UC 5: if an SCC requires a cap to be dropped it should accept
 		// a manual request to drop the cap.
 		"should accept cap drop when cap is required to be dropped": {
-			pod:        createPodWithCaps(&coreapi.Capabilities{Drop: []coreapi.Capability{"foo"}}),
+			caps:       &coreapi.Capabilities{Drop: []coreapi.Capability{"foo"}},
 			sccs:       []*securityv1.SecurityContextConstraints{restricted, requiresFooToBeDropped},
 			shouldPass: true,
 		},
 		// UC 6: required add is defaulted
 		"required add is defaulted": {
-			pod:        goodPod(),
 			sccs:       []*securityv1.SecurityContextConstraints{allowsFooInRequired},
 			shouldPass: true,
 			expectedCapabilities: &coreapi.Capabilities{
@@ -150,7 +152,6 @@ func TestAdmitCaps(t *testing.T) {
 		},
 		// UC 7: required drop is defaulted
 		"required drop is defaulted": {
-			pod:        goodPod(),
 			sccs:       []*securityv1.SecurityContextConstraints{requiresFooToBeDropped},
 			shouldPass: true,
 			expectedCapabilities: &coreapi.Capabilities{
@@ -159,32 +160,46 @@ func TestAdmitCaps(t *testing.T) {
 		},
 		// UC 8: using '*' in allowed caps
 		"should accept cap add when all caps are allowed": {
-			pod:        createPodWithCaps(&coreapi.Capabilities{Add: []coreapi.Capability{"foo"}}),
+			caps:       &coreapi.Capabilities{Add: []coreapi.Capability{"foo"}},
 			sccs:       []*securityv1.SecurityContextConstraints{restricted, allowAllInAllowed},
 			shouldPass: true,
 		},
 	}
 
-	for i := 0; i < 2; i++ {
-		for k, v := range tc {
-			t.Run(k, func(t *testing.T) {
-				v.pod.Spec.Containers, v.pod.Spec.InitContainers = v.pod.Spec.InitContainers, v.pod.Spec.Containers
-
-				testSCCAdmit(k, v.sccs, v.pod, v.shouldPass, t)
-
-				containers := v.pod.Spec.Containers
-				if i == 0 {
-					containers = v.pod.Spec.InitContainers
+	for k, v := range tc {
+		for i := 0; i < 3; i++ {
+			pod := goodPod()
+			if v.caps != nil {
+				pod = createPodWithCaps(v.caps)
+				switch i {
+				case 1:
+					// test init containers
+					pod.Spec.Containers, pod.Spec.InitContainers = nil, pod.Spec.Containers
+				case 2:
+					// test ephemeral containers
+					for _, c := range pod.Spec.Containers {
+						pod.Spec.EphemeralContainers = append(pod.Spec.EphemeralContainers, coreapi.EphemeralContainer{EphemeralContainerCommon: coreapi.EphemeralContainerCommon{SecurityContext: c.SecurityContext}})
+					}
+					pod.Spec.Containers = nil
 				}
+			}
+
+			t.Run(fmt.Sprintf("%s-%d", k, i), func(t *testing.T) {
+				testSCCAdmit(k, v.sccs, pod, v.shouldPass, t)
 
 				if v.expectedCapabilities != nil {
-					if !reflect.DeepEqual(v.expectedCapabilities, containers[0].SecurityContext.Capabilities) {
-						t.Errorf("%s resulted in caps that were not expected - expected: %#v, received: %#v", k, v.expectedCapabilities, containers[0].SecurityContext.Capabilities)
-					}
+					podhelpers.VisitContainersWithPath(
+						&pod.Spec, field.NewPath("testPodSpec"), func(container *coreapi.Container, path *field.Path) bool {
+							if !reflect.DeepEqual(v.expectedCapabilities, container.SecurityContext.Capabilities) {
+								t.Errorf("%s resulted in caps that were not expected at path %q - expected: %#v, received: %#v", k, path.String(), v.expectedCapabilities, container.SecurityContext.Capabilities)
+							}
+							return true
+						})
 				}
 			})
 		}
 	}
+
 }
 
 func TestShouldIgnore(t *testing.T) {

--- a/pkg/securitycontextconstraints/sccmatching/matcher.go
+++ b/pkg/securitycontextconstraints/sccmatching/matcher.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
+	podhelpers "k8s.io/kubernetes/pkg/apis/core/pods"
 
 	"github.com/openshift/api/security"
 	securityv1 "github.com/openshift/api/security/v1"
@@ -123,15 +124,10 @@ func AssignSecurityContext(provider SecurityContextConstraintsProvider, pod *kap
 	pod.Annotations = generatedAnnotations
 	errs = append(errs, provider.ValidatePodSecurityContext(pod, fldPath.Child("spec", "securityContext"))...)
 
-	for i := range pod.Spec.InitContainers {
-		errs = append(errs, assignContainerSecurityContext(provider, pod, &pod.Spec.InitContainers[i], field.NewPath("spec", "initContainers").Index(i).Child("securityContext"))...)
-	}
-	for i := range pod.Spec.EphemeralContainers {
-		errs = append(errs, assignContainerSecurityContext(provider, pod, (*kapi.Container)(&pod.Spec.EphemeralContainers[i].EphemeralContainerCommon), field.NewPath("spec", "ephemeralContainers").Index(i).Child("securityContext"))...)
-	}
-	for i := range pod.Spec.Containers {
-		errs = append(errs, assignContainerSecurityContext(provider, pod, &pod.Spec.Containers[i], field.NewPath("spec", "containers").Index(i).Child("securityContext"))...)
-	}
+	podhelpers.VisitContainersWithPath(&pod.Spec, fldPath, func(container *kapi.Container, path *field.Path) bool {
+		errs = append(errs, assignContainerSecurityContext(provider, pod, container, path)...)
+		return true
+	})
 
 	if len(errs) > 0 {
 		return errs

--- a/vendor/k8s.io/kubernetes/pkg/apis/core/pods/helpers.go
+++ b/vendor/k8s.io/kubernetes/pkg/apis/core/pods/helpers.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pods
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/fieldpath"
+)
+
+// ContainerVisitorWithPath is called with each container and the field.Path to that container,
+// and returns true if visiting should continue.
+type ContainerVisitorWithPath func(container *api.Container, path *field.Path) bool
+
+// VisitContainersWithPath invokes the visitor function with a pointer to the spec
+// of every container in the given pod spec and the field.Path to that container.
+// If visitor returns false, visiting is short-circuited. VisitContainersWithPath returns true if visiting completes,
+// false if visiting was short-circuited.
+func VisitContainersWithPath(podSpec *api.PodSpec, specPath *field.Path, visitor ContainerVisitorWithPath) bool {
+	fldPath := specPath.Child("initContainers")
+	for i := range podSpec.InitContainers {
+		if !visitor(&podSpec.InitContainers[i], fldPath.Index(i)) {
+			return false
+		}
+	}
+	fldPath = specPath.Child("containers")
+	for i := range podSpec.Containers {
+		if !visitor(&podSpec.Containers[i], fldPath.Index(i)) {
+			return false
+		}
+	}
+	if utilfeature.DefaultFeatureGate.Enabled(features.EphemeralContainers) {
+		fldPath = specPath.Child("ephemeralContainers")
+		for i := range podSpec.EphemeralContainers {
+			if !visitor((*api.Container)(&podSpec.EphemeralContainers[i].EphemeralContainerCommon), fldPath.Index(i)) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// ConvertDownwardAPIFieldLabel converts the specified downward API field label
+// and its value in the pod of the specified version to the internal version,
+// and returns the converted label and value. This function returns an error if
+// the conversion fails.
+func ConvertDownwardAPIFieldLabel(version, label, value string) (string, string, error) {
+	if version != "v1" {
+		return "", "", fmt.Errorf("unsupported pod version: %s", version)
+	}
+
+	if path, _, ok := fieldpath.SplitMaybeSubscriptedPath(label); ok {
+		switch path {
+		case "metadata.annotations", "metadata.labels":
+			return label, value, nil
+		default:
+			return "", "", fmt.Errorf("field label does not support subscript: %s", label)
+		}
+	}
+
+	switch label {
+	case "metadata.annotations",
+		"metadata.labels",
+		"metadata.name",
+		"metadata.namespace",
+		"metadata.uid",
+		"spec.nodeName",
+		"spec.restartPolicy",
+		"spec.serviceAccountName",
+		"spec.schedulerName",
+		"status.phase",
+		"status.hostIP",
+		"status.podIP",
+		"status.podIPs":
+		return label, value, nil
+	// This is for backwards compatibility with old v1 clients which send spec.host
+	case "spec.host":
+		return "spec.nodeName", value, nil
+	default:
+		return "", "", fmt.Errorf("field label not supported: %s", label)
+	}
+}

--- a/vendor/k8s.io/kubernetes/pkg/fieldpath/doc.go
+++ b/vendor/k8s.io/kubernetes/pkg/fieldpath/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package fieldpath supplies methods for extracting fields from objects
+// given a path to a field.
+package fieldpath // import "k8s.io/kubernetes/pkg/fieldpath"

--- a/vendor/k8s.io/kubernetes/pkg/fieldpath/fieldpath.go
+++ b/vendor/k8s.io/kubernetes/pkg/fieldpath/fieldpath.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fieldpath
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+// FormatMap formats map[string]string to a string.
+func FormatMap(m map[string]string) (fmtStr string) {
+	// output with keys in sorted order to provide stable output
+	keys := sets.NewString()
+	for key := range m {
+		keys.Insert(key)
+	}
+	for _, key := range keys.List() {
+		fmtStr += fmt.Sprintf("%v=%q\n", key, m[key])
+	}
+	fmtStr = strings.TrimSuffix(fmtStr, "\n")
+
+	return
+}
+
+// ExtractFieldPathAsString extracts the field from the given object
+// and returns it as a string.  The object must be a pointer to an
+// API type.
+func ExtractFieldPathAsString(obj interface{}, fieldPath string) (string, error) {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return "", err
+	}
+
+	if path, subscript, ok := SplitMaybeSubscriptedPath(fieldPath); ok {
+		switch path {
+		case "metadata.annotations":
+			if errs := validation.IsQualifiedName(strings.ToLower(subscript)); len(errs) != 0 {
+				return "", fmt.Errorf("invalid key subscript in %s: %s", fieldPath, strings.Join(errs, ";"))
+			}
+			return accessor.GetAnnotations()[subscript], nil
+		case "metadata.labels":
+			if errs := validation.IsQualifiedName(subscript); len(errs) != 0 {
+				return "", fmt.Errorf("invalid key subscript in %s: %s", fieldPath, strings.Join(errs, ";"))
+			}
+			return accessor.GetLabels()[subscript], nil
+		default:
+			return "", fmt.Errorf("fieldPath %q does not support subscript", fieldPath)
+		}
+	}
+
+	switch fieldPath {
+	case "metadata.annotations":
+		return FormatMap(accessor.GetAnnotations()), nil
+	case "metadata.labels":
+		return FormatMap(accessor.GetLabels()), nil
+	case "metadata.name":
+		return accessor.GetName(), nil
+	case "metadata.namespace":
+		return accessor.GetNamespace(), nil
+	case "metadata.uid":
+		return string(accessor.GetUID()), nil
+	}
+
+	return "", fmt.Errorf("unsupported fieldPath: %v", fieldPath)
+}
+
+// SplitMaybeSubscriptedPath checks whether the specified fieldPath is
+// subscripted, and
+//  - if yes, this function splits the fieldPath into path and subscript, and
+//    returns (path, subscript, true).
+//  - if no, this function returns (fieldPath, "", false).
+//
+// Example inputs and outputs:
+//  - "metadata.annotations['myKey']" --> ("metadata.annotations", "myKey", true)
+//  - "metadata.annotations['a[b]c']" --> ("metadata.annotations", "a[b]c", true)
+//  - "metadata.labels['']"           --> ("metadata.labels", "", true)
+//  - "metadata.labels"               --> ("metadata.labels", "", false)
+func SplitMaybeSubscriptedPath(fieldPath string) (string, string, bool) {
+	if !strings.HasSuffix(fieldPath, "']") {
+		return fieldPath, "", false
+	}
+	s := strings.TrimSuffix(fieldPath, "']")
+	parts := strings.SplitN(s, "['", 2)
+	if len(parts) < 2 {
+		return fieldPath, "", false
+	}
+	if len(parts[0]) == 0 {
+		return fieldPath, "", false
+	}
+	return parts[0], parts[1], true
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -807,12 +807,14 @@ k8s.io/kubernetes/pkg/apis/autoscaling
 k8s.io/kubernetes/pkg/apis/batch
 k8s.io/kubernetes/pkg/apis/core
 k8s.io/kubernetes/pkg/apis/core/helper
+k8s.io/kubernetes/pkg/apis/core/pods
 k8s.io/kubernetes/pkg/apis/core/v1
 k8s.io/kubernetes/pkg/apis/core/v1/helper
 k8s.io/kubernetes/pkg/apis/core/v1/helper/qos
 k8s.io/kubernetes/pkg/apis/rbac
 k8s.io/kubernetes/pkg/apis/rbac/v1
 k8s.io/kubernetes/pkg/features
+k8s.io/kubernetes/pkg/fieldpath
 k8s.io/kubernetes/pkg/quota/v1/evaluator/core
 k8s.io/kubernetes/pkg/quota/v1/install
 k8s.io/kubernetes/pkg/registry/rbac
@@ -868,3 +870,4 @@ sigs.k8s.io/yaml
 # k8s.io/mount-utils => k8s.io/mount-utils v0.23.0
 # k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.23.0
 # k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.23.0
+# vbom.ml/util => github.com/fvbommel/util v0.0.0-20180919145318-efcd4e0f9787


### PR DESCRIPTION
cherry-pick of #113

Conflict resolution:
- remove tests specific to Linux/Windows OS fields - the field was not present
- vendor in podhelpers to walk containers

/assign @s-urbaniak 
/assign @deads2k 

We'll need approval for the go.mod changes

The vbom is necessary because of library-go@release-4.10