### PR TITLE
OCPBUGS-42019:[release-4.17] pkg: add missing safe sysctls to the list of SafeSysctlAllowlist

### DIFF
--- a/pkg/securitycontextconstraints/sysctl/mustmatchpatterns.go
+++ b/pkg/securitycontextconstraints/sysctl/mustmatchpatterns.go
@@ -36,6 +36,10 @@ func SafeSysctlAllowlist() []string {
 		"net.ipv4.tcp_syncookies",
 		"net.ipv4.ping_group_range",
 		"net.ipv4.ip_unprivileged_port_start",
+		"net.ipv4.tcp_keepalive_time",
+		"net.ipv4.tcp_fin_timeout",
+		"net.ipv4.tcp_keepalive_intvl",
+		"net.ipv4.tcp_keepalive_probes",
 	}
 }
 


### PR DESCRIPTION
As part of Kubernetes v1.29, several sysctls [1] have been added to the SafeSysctlAllowlist. However, that list has not yet been updated in OCP. This change addresses that issue.

[1] https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/#safe-and-unsafe-sysctls