### PR TITLE
pkg/scc: update current SCC owners

### DIFF
--- a/pkg/securitycontextconstraints/OWNERS
+++ b/pkg/securitycontextconstraints/OWNERS
@@ -1,8 +1,5 @@
 reviewers:
-  - s-urbaniak
-  - slaskawi
+  - liouk
   - ibihim
-  - stlaz
 approvers:
-  - stlaz
-  - s-urbaniak
+  - ibihim


### PR DESCRIPTION
## What

- Remove non-Red-Hatters.
- Add @liouk as reviewer.
- Bump me (@ibihim) to approver.

## Why

Reflect current ownership status.