### PR TITLE
CNTRLPLANE-179: set scc annotation min

### DIFF
--- a/pkg/securitycontextconstraints/sccadmission/admission.go
+++ b/pkg/securitycontextconstraints/sccadmission/admission.go
@@ -593,18 +593,20 @@ func (c *constraint) listSortedSCCs(
 
 	sort.Sort(sccsort.ByPriority(constraints))
 
+	if specMutationAllowed {
+		return constraints, nil
+	}
+
 	// If mutation is not allowed and validatedSCCHint is provided, check the validated policy first.
 	// Keep the order the same for everything else
 	sort.SliceStable(constraints, func(i, j int) bool {
 		// disregard the ephemeral containers here, the rest of the pod should still
 		// not get mutated and so we are primarily interested in the SCC that matched previously
-		if !specMutationAllowed {
-			if constraints[i].Name == validatedSCCHint {
-				return true
-			}
-			if constraints[j].Name == validatedSCCHint {
-				return false
-			}
+		if constraints[i].Name == validatedSCCHint {
+			return true
+		}
+		if constraints[j].Name == validatedSCCHint {
+			return false
 		}
 		return i < j
 	})

--- a/pkg/securitycontextconstraints/sccadmission/admission_test.go
+++ b/pkg/securitycontextconstraints/sccadmission/admission_test.go
@@ -11,6 +11,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/admission"
@@ -1637,6 +1638,181 @@ func TestAdmitValidatedSCCSubjectType(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestListOrderedSCCs(t *testing.T) {
+	sccLow := &securityv1.SecurityContextConstraints{
+		ObjectMeta: metav1.ObjectMeta{Name: "low-priority"},
+		Priority:   ptr.To[int32](10),
+	}
+
+	sccMedium := &securityv1.SecurityContextConstraints{
+		ObjectMeta: metav1.ObjectMeta{Name: "medium-priority"},
+		Priority:   ptr.To[int32](20),
+	}
+
+	sccHigh := &securityv1.SecurityContextConstraints{
+		ObjectMeta: metav1.ObjectMeta{Name: "high-priority"},
+		Priority:   ptr.To[int32](30),
+	}
+
+	sccHighest := &securityv1.SecurityContextConstraints{
+		ObjectMeta: metav1.ObjectMeta{Name: "highest-priority"},
+		Priority:   ptr.To[int32](40),
+	}
+
+	allSCCs := []*securityv1.SecurityContextConstraints{sccLow, sccMedium, sccHigh, sccHighest}
+
+	tests := []struct {
+		name                string
+		requiredSCCName     string
+		validatedSCCHint    string
+		specMutationAllowed bool
+		mockLister          securityv1listers.SecurityContextConstraintsLister
+		expectedSCCs        []*securityv1.SecurityContextConstraints
+		expectError         bool
+		errorContains       string
+	}{
+		{
+			name:                "list all SCCs and sort by priority",
+			requiredSCCName:     "",
+			validatedSCCHint:    "",
+			specMutationAllowed: true,
+			mockLister:          newMockSCCLister(allSCCs, nil),
+			expectedSCCs:        []*securityv1.SecurityContextConstraints{sccHighest, sccHigh, sccMedium, sccLow},
+			expectError:         false,
+		},
+		{
+			name:                "get specific required SCC",
+			requiredSCCName:     "medium-priority",
+			validatedSCCHint:    "",
+			specMutationAllowed: true,
+			mockLister:          newMockSCCLister(allSCCs, nil),
+			expectedSCCs:        []*securityv1.SecurityContextConstraints{sccMedium},
+			expectError:         false,
+		},
+		{
+			name:                "error when required SCC not found",
+			requiredSCCName:     "non-existent",
+			validatedSCCHint:    "",
+			specMutationAllowed: true,
+			mockLister:          newMockSCCLister(allSCCs, nil),
+			expectedSCCs:        nil,
+			expectError:         true,
+			errorContains:       "failed to retrieve the required SCC",
+		},
+		{
+			name:                "error when no SCCs found",
+			requiredSCCName:     "",
+			validatedSCCHint:    "",
+			specMutationAllowed: true,
+			mockLister:          newMockSCCLister([]*securityv1.SecurityContextConstraints{}, nil),
+			expectedSCCs:        nil,
+			expectError:         true,
+			errorContains:       "no SecurityContextConstraints found in cluster",
+		},
+		{
+			name:                "prioritize validatedSCCHint when specMutationAllowed is false",
+			requiredSCCName:     "",
+			validatedSCCHint:    "low-priority",
+			specMutationAllowed: false,
+			mockLister:          newMockSCCLister(allSCCs, nil),
+			// low-priority should come first despite having lowest priority
+			expectedSCCs: []*securityv1.SecurityContextConstraints{sccLow, sccHighest, sccHigh, sccMedium},
+			expectError:  false,
+		},
+		{
+			name:                "validatedSCCHint ignored when specMutationAllowed is true",
+			requiredSCCName:     "",
+			validatedSCCHint:    "low-priority",
+			specMutationAllowed: true,
+			mockLister:          newMockSCCLister(allSCCs, nil),
+			// Normal priority order when specMutationAllowed is true
+			expectedSCCs: []*securityv1.SecurityContextConstraints{sccHighest, sccHigh, sccMedium, sccLow},
+			expectError:  false,
+		},
+		{
+			name:                "error from lister.List",
+			requiredSCCName:     "",
+			validatedSCCHint:    "",
+			specMutationAllowed: true,
+			mockLister:          newMockSCCLister(nil, fmt.Errorf("lister error")),
+			expectedSCCs:        nil,
+			expectError:         true,
+			errorContains:       "lister error",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &constraint{sccLister: tc.mockLister}
+
+			result, err := c.listSortedSCCs(tc.requiredSCCName, tc.validatedSCCHint, tc.specMutationAllowed)
+
+			// Check error expectations
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+					return
+				} else if tc.errorContains != "" && !strings.Contains(err.Error(), tc.errorContains) {
+					t.Errorf("Expected error containing %q but got %q", tc.errorContains, err.Error())
+				}
+				return
+			}
+
+			// No error expected but got one
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			// Check result expectations
+			if !reflect.DeepEqual(result, tc.expectedSCCs) {
+				t.Errorf("Expected SCCs order: %v, got: %v", getSCCNames(tc.expectedSCCs), getSCCNames(result))
+			}
+		})
+	}
+}
+
+// Helper to compare SCC lists in error messages
+func getSCCNames(sccs []*securityv1.SecurityContextConstraints) []string {
+	names := make([]string, len(sccs))
+	for i, scc := range sccs {
+		names[i] = scc.Name
+	}
+	return names
+}
+
+// Mock SCC lister for testing
+type mockSCCLister struct {
+	sccs []*securityv1.SecurityContextConstraints
+	err  error
+}
+
+func newMockSCCLister(sccs []*securityv1.SecurityContextConstraints, err error) securityv1listers.SecurityContextConstraintsLister {
+	return &mockSCCLister{sccs: sccs, err: err}
+}
+
+func (m *mockSCCLister) List(selector labels.Selector) ([]*securityv1.SecurityContextConstraints, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	return m.sccs, nil
+}
+
+func (m *mockSCCLister) Get(name string) (*securityv1.SecurityContextConstraints, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	for _, scc := range m.sccs {
+		if scc.Name == name {
+			return scc, nil
+		}
+	}
+
+	return nil, fmt.Errorf("%s not found", name)
 }
 
 // testSCCAdmission is a helper to admit the pod and ensure it was validated against the expected

--- a/pkg/securitycontextconstraints/sccadmission/scc_authz_check.go
+++ b/pkg/securitycontextconstraints/sccadmission/scc_authz_check.go
@@ -1,0 +1,62 @@
+package sccadmission
+
+import (
+	"context"
+
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/authentication/serviceaccount"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+
+	"github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/sccmatching"
+)
+
+const (
+	allowedForUser = "user"
+	allowedForSA   = "serviceaccount"
+	allowedForNone = "none"
+)
+
+type sccAuthorizationChecker struct {
+	authz              authorizer.Authorizer
+	userInfo           user.Info
+	namespace          string
+	serviceAccountName string
+}
+
+func newSCCAuthorizerChecker(authz authorizer.Authorizer, attr admission.Attributes, serviceAccountName string) *sccAuthorizationChecker {
+	return &sccAuthorizationChecker{
+		authz:              authz,
+		userInfo:           attr.GetUserInfo(),
+		namespace:          attr.GetNamespace(),
+		serviceAccountName: serviceAccountName,
+	}
+}
+
+func (c *sccAuthorizationChecker) allowedForType(ctx context.Context, provider sccmatching.SecurityContextConstraintsProvider) string {
+	sccName := provider.GetSCCName()
+	sccUsers := provider.GetSCCUsers()
+	sccGroups := provider.GetSCCGroups()
+
+	if len(c.serviceAccountName) != 0 {
+		saUserInfo := serviceaccount.UserInfo(c.namespace, c.serviceAccountName, "")
+
+		if sccmatching.ConstraintAppliesTo(
+			ctx,
+			sccName, sccUsers, sccGroups,
+			saUserInfo, c.namespace, c.authz,
+		) {
+			return allowedForSA
+		}
+	}
+
+	if sccmatching.ConstraintAppliesTo(
+		ctx,
+		sccName, sccUsers, sccGroups,
+		c.userInfo, c.namespace, c.authz,
+	) {
+		return allowedForUser
+	}
+
+	return allowedForNone
+}

--- a/pkg/securitycontextconstraints/sccadmission/scc_authz_check_test.go
+++ b/pkg/securitycontextconstraints/sccadmission/scc_authz_check_test.go
@@ -1,0 +1,112 @@
+package sccadmission
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/sccmatching"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/authentication/user"
+	coreapi "k8s.io/kubernetes/pkg/apis/core"
+)
+
+func TestSCCAuthorizationChecker(t *testing.T) {
+	userSCC := laxSCC()
+	userSCC.Name = "user-scc"
+	userSCC.Users = []string{"test-user"}
+	userSCC.Groups = []string{}
+
+	saSCC := laxSCC()
+	saSCC.Name = "sa-scc"
+	saSCC.Users = []string{}
+	saSCC.Groups = []string{}
+
+	userName := "test-user"
+	saName := "system:serviceaccount:test-ns:default"
+
+	tests := []struct {
+		testName  string
+		user      string
+		namespace string
+		scc       string
+		expected  string
+	}{
+		{
+			testName:  "user authorization only",
+			user:      userName,
+			namespace: "test-ns",
+			scc:       "user-scc",
+			expected:  "user",
+		},
+		{
+			testName:  "service account authorization only",
+			user:      saName,
+			namespace: "test-ns",
+			scc:       "sa-scc",
+			expected:  "serviceaccount",
+		},
+		{
+			testName:  "both authorized - should prefer service account",
+			user:      saName,
+			namespace: "test-ns",
+			scc:       "sa-scc",
+			expected:  "serviceaccount",
+		},
+		{
+			testName:  "neither authorized",
+			user:      "different-user",
+			namespace: "test-ns",
+			scc:       "sa-scc", // Can't use user-scc, which contains the user. Will lead into SAR fake request.
+			expected:  "none",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			testAuthorizer := &sccTestAuthorizer{
+				t:         t,
+				user:      test.user,
+				namespace: test.namespace,
+				scc:       test.scc,
+			}
+
+			// Only matter in user scenario / where SA isn't authorized.
+			userInfo := &user.DefaultInfo{
+				Name: userName,
+			}
+
+			attr := admission.NewAttributesRecord(
+				nil, nil,
+				coreapi.Kind("Pod").WithVersion("version"),
+				test.namespace, "pod-name",
+				coreapi.Resource("pods").WithVersion("version"), "",
+				admission.Create, nil,
+				false,
+				userInfo,
+			)
+
+			checker := newSCCAuthorizerChecker(
+				testAuthorizer,
+				attr,
+				"default",
+			)
+
+			// Transform SCC into Provider.
+			var provider sccmatching.SecurityContextConstraintsProvider
+			var err error
+			if test.scc == "user-scc" {
+				provider, err = sccmatching.NewSimpleProvider(userSCC)
+			} else {
+				provider, err = sccmatching.NewSimpleProvider(saSCC)
+			}
+			if err != nil {
+				t.Fatalf("Error creating provider: %v", err)
+			}
+
+			result := checker.allowedForType(context.Background(), provider)
+			if result != test.expected {
+				t.Errorf("Expected allowedFor to return %q but got %q", test.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

- Add annotation for "SCC is allowed for {user / serviceaccount}"
- Minor refactoring
- Bump deprecated functions

## Why

Annotation:
- The psa label syncer ignores user-based SCC decisions. This leads to issues, where the SCC is set to something less strict, but the syncer sees only restricted-v2.

Refactoring:
- The code is hard to read and some minor refactorings might lead to a future, where the code is more readable and we have one single function of doom handling validate and mutation.