### PR TITLE
OCPBUGS-59811: pkg/configflags: write default audit policy file to absolute dir

### DIFF
--- a/pkg/configflags/audit.go
+++ b/pkg/configflags/audit.go
@@ -11,7 +11,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 )
 
-const defaultAuditPolicyFilePath = "openshift.local.audit/policy.yaml"
+const defaultAuditPolicyFilePath = "/tmp/openshift.local.audit/policy.yaml"
 
 func AuditFlags(c *configv1.AuditConfig, args map[string][]string) map[string][]string {
 	if !c.Enabled {


### PR DESCRIPTION
Instead of using relative directory we should specify absolute path, so that container root could be read-only.