### PR TITLE
NO-JIRA: Use utilkernel constants instead of hardcoded values for safe sysctls

### DIFF
--- a/pkg/securitycontextconstraints/sysctl/mustmatchpatterns.go
+++ b/pkg/securitycontextconstraints/sysctl/mustmatchpatterns.go
@@ -55,13 +55,13 @@ var legacySafeSysctls = []string{
 var newerSysctls = []sysctl{
 	{
 		name:   "net.ipv4.ip_local_reserved_ports",
-		kernel: "3.16",
+		kernel: utilkernel.IPLocalReservedPortsNamespacedKernelVersion,
 	}, {
 		name:   "net.ipv4.tcp_rmem",
-		kernel: "4.15",
+		kernel: utilkernel.TCPReceiveMemoryNamespacedKernelVersion,
 	}, {
 		name:   "net.ipv4.tcp_wmem",
-		kernel: "4.15",
+		kernel: utilkernel.TCPTransmitMemoryNamespacedKernelVersion,
 	},
 }
 


### PR DESCRIPTION
Previously, safe sysctl checks were using hardcoded kernel versions(e.g., "4.16"). This change replaces the hardcoded values with the corresponding utilkernel constants (e.g., `IPLocalReservedPortsNamespacedKernelVersion`).