### PR TITLE
OCPBUGS-58313: Admit sysctls based on the worker node kernel version instead of the current node kernel version

### DIFF
--- a/pkg/securitycontextconstraints/sccadmission/admission.go
+++ b/pkg/securitycontextconstraints/sccadmission/admission.go
@@ -47,6 +47,7 @@ type constraint struct {
 	*admission.Handler
 	sccLister       securityv1listers.SecurityContextConstraintsLister
 	namespaceLister corev1listers.NamespaceLister
+	nodeLister      corev1listers.NodeLister
 	listersSynced   []cache.InformerSynced
 	authorizer      authorizer.Authorizer
 }
@@ -213,7 +214,7 @@ func (c *constraint) computeSecurityContext(
 		return nil, nil, nil, admission.NewForbidden(a, err)
 	}
 
-	providers, errs := sccmatching.CreateProvidersFromConstraints(ctx, a.GetNamespace(), constraints, c.namespaceLister)
+	providers, errs := sccmatching.CreateProvidersFromConstraints(ctx, a.GetNamespace(), constraints, c.namespaceLister, c.nodeLister)
 	logProviders(pod, providers, errs)
 	if len(errs) > 0 {
 		return nil, nil, nil, kutilerrors.NewAggregate(errs)
@@ -519,7 +520,12 @@ func (c *constraint) SetSecurityInformers(informers securityv1informer.SecurityC
 
 func (c *constraint) SetExternalKubeInformerFactory(informers informers.SharedInformerFactory) {
 	c.namespaceLister = informers.Core().V1().Namespaces().Lister()
-	c.listersSynced = append(c.listersSynced, informers.Core().V1().Namespaces().Informer().HasSynced)
+	c.nodeLister = informers.Core().V1().Nodes().Lister()
+	c.listersSynced = append(
+		c.listersSynced,
+		informers.Core().V1().Namespaces().Informer().HasSynced,
+		informers.Core().V1().Nodes().Informer().HasSynced,
+	)
 }
 
 func (c *constraint) SetAuthorizer(authorizer authorizer.Authorizer) {
@@ -536,6 +542,9 @@ func (c *constraint) ValidateInitialization() error {
 	}
 	if c.namespaceLister == nil {
 		return fmt.Errorf("%s requires a namespaceLister", PluginName)
+	}
+	if c.nodeLister == nil {
+		return fmt.Errorf("%s requires a nodeLister", PluginName)
 	}
 	if c.authorizer == nil {
 		return fmt.Errorf("%s requires an authorizer", PluginName)

--- a/pkg/securitycontextconstraints/sccadmission/admission_test.go
+++ b/pkg/securitycontextconstraints/sccadmission/admission_test.go
@@ -29,8 +29,28 @@ import (
 	securityv1listers "github.com/openshift/client-go/security/listers/security/v1"
 
 	"github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/sccmatching"
+	"github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/sysctl"
 	sccsort "github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/util/sort"
 )
+
+// testNodeLister is a simple implementation for testing that returns empty node list
+type testNodeLister struct{}
+
+func (f *testNodeLister) List(selector labels.Selector) ([]*corev1.Node, error) {
+	return []*corev1.Node{}, nil
+}
+
+func (f *testNodeLister) Get(name string) (*corev1.Node, error) {
+	return nil, fmt.Errorf("node %s not found", name)
+}
+
+var _ corev1listers.NodeLister = &testNodeLister{}
+
+// getTestSysctls returns a default set of sysctls for testing purposes.
+// This mimics the behavior of sysctl.SafeSysctlAllowlist with a testNodeLister.
+func getTestSysctls() []string {
+	return sysctl.SafeSysctlAllowlist(&testNodeLister{})
+}
 
 // createSAForTest Build and Initializes a ServiceAccount for tests
 func createSAForTest() *corev1.ServiceAccount {
@@ -60,6 +80,7 @@ func newTestAdmission(sccLister securityv1listers.SecurityContextConstraintsList
 	return &constraint{
 		Handler:         admission.NewHandler(admission.Create),
 		namespaceLister: nsLister,
+		nodeLister:      &testNodeLister{},
 		sccLister:       sccLister,
 		listersSynced:   []cache.InformerSynced{func() bool { return true }},
 		authorizer:      authorizer,
@@ -987,7 +1008,7 @@ func TestCreateProvidersFromConstraints(t *testing.T) {
 			// let timeout based failures fail fast
 			ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 			defer cancel()
-			_, errs := sccmatching.CreateProvidersFromConstraints(ctx, attributes.GetNamespace(), []*securityv1.SecurityContextConstraints{scc}, nsLister)
+			_, errs := sccmatching.CreateProvidersFromConstraints(ctx, attributes.GetNamespace(), []*securityv1.SecurityContextConstraints{scc}, nsLister, &testNodeLister{})
 
 			if !reflect.DeepEqual(scc, v.scc()) {
 				diff := diff.Diff(scc, v.scc())
@@ -1390,7 +1411,7 @@ func TestAdmitPreferNonmutatingWhenPossible(t *testing.T) {
 		},
 	}
 
-	mutatingProvider, err := sccmatching.NewSimpleProvider(mutatingSCC)
+	mutatingProvider, err := sccmatching.NewSimpleProvider(mutatingSCC, getTestSysctls())
 	if err != nil {
 		t.Fatalf("failed to create a mutating provider: %v", err)
 	}

--- a/pkg/securitycontextconstraints/sccadmission/scc_authz_check_test.go
+++ b/pkg/securitycontextconstraints/sccadmission/scc_authz_check_test.go
@@ -2,13 +2,30 @@ package sccadmission
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/sccmatching"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/authentication/user"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 	coreapi "k8s.io/kubernetes/pkg/apis/core"
 )
+
+// fakeNodeLister is a simple implementation for testing that returns empty node list
+type fakeNodeLister struct{}
+
+func (f *fakeNodeLister) List(selector labels.Selector) ([]*corev1.Node, error) {
+	return []*corev1.Node{}, nil
+}
+
+func (f *fakeNodeLister) Get(name string) (*corev1.Node, error) {
+	return nil, fmt.Errorf("node %s not found", name)
+}
+
+var _ corev1listers.NodeLister = &fakeNodeLister{}
 
 func TestSCCAuthorizationChecker(t *testing.T) {
 	userSCC := laxSCC()
@@ -95,9 +112,9 @@ func TestSCCAuthorizationChecker(t *testing.T) {
 			var provider sccmatching.SecurityContextConstraintsProvider
 			var err error
 			if test.scc == "user-scc" {
-				provider, err = sccmatching.NewSimpleProvider(userSCC)
+				provider, err = sccmatching.NewSimpleProvider(userSCC, getTestSysctls())
 			} else {
-				provider, err = sccmatching.NewSimpleProvider(saSCC)
+				provider, err = sccmatching.NewSimpleProvider(saSCC, getTestSysctls())
 			}
 			if err != nil {
 				t.Fatalf("Error creating provider: %v", err)

--- a/pkg/securitycontextconstraints/sccmatching/matcher_test.go
+++ b/pkg/securitycontextconstraints/sccmatching/matcher_test.go
@@ -39,7 +39,7 @@ func TestAssignSecurityContext(t *testing.T) {
 			Type: securityv1.SupplementalGroupsStrategyRunAsAny,
 		},
 	}
-	provider, err := NewSimpleProvider(scc)
+	provider, err := NewSimpleProvider(scc, getTestSysctls())
 	if err != nil {
 		t.Fatalf("failed to create provider: %v", err)
 	}

--- a/pkg/securitycontextconstraints/sccmatching/provider.go
+++ b/pkg/securitycontextconstraints/sccmatching/provider.go
@@ -44,7 +44,7 @@ type simpleProvider struct {
 var _ SecurityContextConstraintsProvider = &simpleProvider{}
 
 // NewSimpleProvider creates a new SecurityContextConstraintsProvider instance.
-func NewSimpleProvider(scc *securityv1.SecurityContextConstraints) (SecurityContextConstraintsProvider, error) {
+func NewSimpleProvider(scc *securityv1.SecurityContextConstraints, availableSysCtls []string) (SecurityContextConstraintsProvider, error) {
 	if scc == nil {
 		return nil, fmt.Errorf("NewSimpleProvider requires a SecurityContextConstraints")
 	}
@@ -79,7 +79,7 @@ func NewSimpleProvider(scc *securityv1.SecurityContextConstraints) (SecurityCont
 		return nil, err
 	}
 
-	sysctlsStrat, err := createSysctlsStrategy(sysctl.SafeSysctlAllowlist(), scc.AllowedUnsafeSysctls, scc.ForbiddenSysctls)
+	sysctlsStrat, err := createSysctlsStrategy(availableSysCtls, scc.AllowedUnsafeSysctls, scc.ForbiddenSysctls)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/securitycontextconstraints/sccmatching/provider_test.go
+++ b/pkg/securitycontextconstraints/sccmatching/provider_test.go
@@ -12,14 +12,36 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/utils/pointer"
 
 	securityv1 "github.com/openshift/api/security/v1"
+	"github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/sysctl"
 	sccutil "github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/util"
 )
+
+// fakeNodeLister is a simple implementation for testing that returns empty node list
+type fakeNodeLister struct{}
+
+func (f *fakeNodeLister) List(selector labels.Selector) ([]*corev1.Node, error) {
+	return []*corev1.Node{}, nil
+}
+
+func (f *fakeNodeLister) Get(name string) (*corev1.Node, error) {
+	return nil, fmt.Errorf("node %s not found", name)
+}
+
+var _ corev1listers.NodeLister = &fakeNodeLister{}
+
+// getTestSysctls returns a default set of sysctls for testing purposes.
+// This mimics the behavior of sysctl.SafeSysctlAllowlist with a fakeNodeLister.
+func getTestSysctls() []string {
+	return sysctl.SafeSysctlAllowlist(&fakeNodeLister{})
+}
 
 func TestCreatePodSecurityContextNonmutating(t *testing.T) {
 	// Create a pod with a security context that needs filling in
@@ -57,7 +79,7 @@ func TestCreatePodSecurityContextNonmutating(t *testing.T) {
 	pod := createPod()
 	scc := createSCC()
 
-	provider, err := NewSimpleProvider(scc)
+	provider, err := NewSimpleProvider(scc, getTestSysctls())
 	if err != nil {
 		t.Fatalf("unable to create provider %v", err)
 	}
@@ -114,7 +136,7 @@ func TestCreateContainerSecurityContextNonmutating(t *testing.T) {
 	pod := createPod()
 	scc := createSCC()
 
-	provider, err := NewSimpleProvider(scc)
+	provider, err := NewSimpleProvider(scc, getTestSysctls())
 	if err != nil {
 		t.Fatalf("unable to create provider %v", err)
 	}
@@ -350,7 +372,7 @@ func TestValidatePodSecurityContextFailures(t *testing.T) {
 		},
 	}
 	for k, v := range errorCases {
-		provider, err := NewSimpleProvider(v.scc)
+		provider, err := NewSimpleProvider(v.scc, getTestSysctls())
 		if err != nil {
 			t.Fatalf("unable to create provider %v", err)
 		}
@@ -492,7 +514,7 @@ func TestValidateContainerSecurityContextFailures(t *testing.T) {
 	}
 
 	for k, v := range errorCases {
-		provider, err := NewSimpleProvider(v.scc)
+		provider, err := NewSimpleProvider(v.scc, getTestSysctls())
 		if err != nil {
 			t.Fatalf("unable to create provider %v", err)
 		}
@@ -713,7 +735,7 @@ func TestValidatePodSecurityContextSuccess(t *testing.T) {
 	}
 
 	for k, v := range successCases {
-		provider, err := NewSimpleProvider(v.scc)
+		provider, err := NewSimpleProvider(v.scc, getTestSysctls())
 		if err != nil {
 			t.Fatalf("unable to create provider %v", err)
 		}
@@ -885,7 +907,7 @@ func TestValidateContainerSecurityContextSuccess(t *testing.T) {
 	}
 
 	for k, v := range successCases {
-		provider, err := NewSimpleProvider(v.scc)
+		provider, err := NewSimpleProvider(v.scc, getTestSysctls())
 		if err != nil {
 			t.Fatalf("unable to create provider %v", err)
 		}
@@ -952,7 +974,7 @@ func TestGenerateContainerSecurityContextReadOnlyRootFS(t *testing.T) {
 	}
 
 	for k, v := range tests {
-		provider, err := NewSimpleProvider(v.scc)
+		provider, err := NewSimpleProvider(v.scc, getTestSysctls())
 		if err != nil {
 			t.Errorf("%s unable to create provider %v", k, err)
 			continue
@@ -1106,7 +1128,7 @@ func TestGenerateNonRootSecurityContextOnNonZeroRunAsUser(t *testing.T) {
 	}
 
 	for k, v := range tests {
-		provider, err := NewSimpleProvider(v.scc)
+		provider, err := NewSimpleProvider(v.scc, getTestSysctls())
 		if err != nil {
 			t.Errorf("%s unable to create provider %v", k, err)
 			continue
@@ -1218,7 +1240,7 @@ func TestValidateAllowedVolumes(t *testing.T) {
 		// create an SCC that allows no volumes
 		scc := defaultSCC()
 
-		provider, err := NewSimpleProvider(scc)
+		provider, err := NewSimpleProvider(scc, getTestSysctls())
 		if err != nil {
 			t.Errorf("error creating provider for %s: %s", fieldVal.Name, err.Error())
 			continue
@@ -1253,7 +1275,7 @@ func TestValidateAllowedVolumes(t *testing.T) {
 func TestValidateProjectedVolume(t *testing.T) {
 	pod := defaultPod()
 	scc := defaultSCC()
-	provider, err := NewSimpleProvider(scc)
+	provider, err := NewSimpleProvider(scc, getTestSysctls())
 	require.NoError(t, err, "error creating provider")
 
 	tests := []struct {
@@ -1373,7 +1395,7 @@ func TestValidateAllowPrivilegeEscalation(t *testing.T) {
 	scc := defaultSCC()
 	scc.AllowPrivilegeEscalation = &no
 
-	provider, err := NewSimpleProvider(scc)
+	provider, err := NewSimpleProvider(scc, getTestSysctls())
 	if err != nil {
 		t.Errorf("error creating provider: %v", err.Error())
 	}
@@ -1417,17 +1439,17 @@ func TestValidateAllowPrivilegeEscalation(t *testing.T) {
 }
 
 func TestSeccompAnnotationsFieldsGeneration(t *testing.T) {
-	noSeccompProvider, err := NewSimpleProvider(defaultSCC())
+	noSeccompProvider, err := NewSimpleProvider(defaultSCC(), getTestSysctls())
 	require.NoError(t, err)
 
 	sccWildcardSeccomp := defaultSCC()
 	sccWildcardSeccomp.SeccompProfiles = []string{"*"}
-	wildcardSeccompProvider, err := NewSimpleProvider(sccWildcardSeccomp)
+	wildcardSeccompProvider, err := NewSimpleProvider(sccWildcardSeccomp, getTestSysctls())
 	require.NoError(t, err)
 
 	sccGenerateSeccomp := defaultSCC()
 	sccGenerateSeccomp.SeccompProfiles = []string{corev1.SeccompProfileRuntimeDefault}
-	generateSeccompProvider, err := NewSimpleProvider(sccGenerateSeccomp)
+	generateSeccompProvider, err := NewSimpleProvider(sccGenerateSeccomp, getTestSysctls())
 	require.NoError(t, err)
 
 	podPodSeccompAnnotation := defaultPod()


### PR DESCRIPTION
The sysctls should be admitted based on the worker node kernel version instead of the current node kernel version(kernel version of the machine running api server), to avoid SCC admitting a pod with a sysctl param that is unsafe on the worker's kernel.