### PR TITLE
CNF-23052: Migrate away from deprecated ioutil

### DIFF
--- a/pkg/admission/imagepolicy/imagepolicy.go
+++ b/pkg/admission/imagepolicy/imagepolicy.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"reflect"
 	"strings"
 	"time"
@@ -43,7 +42,7 @@ func Register(plugins *admission.Plugins) {
 		func(input io.Reader) (admission.Interface, error) {
 			config := &imagepolicy.ImagePolicyConfig{}
 			if input != nil {
-				configContent, err := ioutil.ReadAll(input)
+				configContent, err := io.ReadAll(input)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/admission/imagepolicy/imagepolicy_test.go
+++ b/pkg/admission/imagepolicy/imagepolicy_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"reflect"
 	"strings"
@@ -67,7 +67,7 @@ func TestDefaultPolicy(t *testing.T) {
 		t.Fatal(err)
 	}
 	config := &imagepolicy.ImagePolicyConfig{}
-	configContent, err := ioutil.ReadAll(input)
+	configContent, err := io.ReadAll(input)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -492,7 +492,7 @@ func TestAdmissionResolveImages(t *testing.T) {
 	}
 
 	defaultPolicyConfig := &imagepolicy.ImagePolicyConfig{}
-	configContent, err := ioutil.ReadAll(bytes.NewBufferString(`{"kind":"ImagePolicyConfig","apiVersion":"image.openshift.io/v1"}`))
+	configContent, err := io.ReadAll(bytes.NewBufferString(`{"kind":"ImagePolicyConfig","apiVersion":"image.openshift.io/v1"}`))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/configflags/audit.go
+++ b/pkg/configflags/audit.go
@@ -1,7 +1,6 @@
 package configflags
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -26,7 +25,7 @@ func AuditFlags(c *configv1.AuditConfig, args map[string][]string) map[string][]
 		if err := os.MkdirAll(filepath.Dir(auditPolicyFilePath), 0755); err != nil {
 			utilruntime.HandleError(err)
 		}
-		if err := ioutil.WriteFile(auditPolicyFilePath, c.PolicyConfiguration.Raw, 0644); err != nil {
+		if err := os.WriteFile(auditPolicyFilePath, c.PolicyConfiguration.Raw, 0644); err != nil {
 			utilruntime.HandleError(err)
 		}
 	}


### PR DESCRIPTION
`ioutil` has been deprecated since Go 1.16: https://go.dev/doc/go1.16#ioutil

Tracking issue: https://github.com/redhat-best-practices-for-k8s/telco-bot/issues/52

**Migration from `ioutil` to `io`/`os`:**

* Replaced `ioutil.ReadAll` with `io.ReadAll` in `imagepolicy.go` and `imagepolicy_test.go` for reading configuration data from readers. [[1]](diffhunk://#diff-cdcdfbefd001b871d1021ed12acc1a956547af51d4bd5ac2b29c4c11a5e94e71L46-R45) [[2]](diffhunk://#diff-0b435b3dedab1dd0fce32a4344a758ae159deafc7e2d61479596c6614a3c543cL70-R70) [[3]](diffhunk://#diff-0b435b3dedab1dd0fce32a4344a758ae159deafc7e2d61479596c6614a3c543cL495-R495)
* Replaced `ioutil.WriteFile` with `os.WriteFile` in `audit.go` for writing audit policy files.

**Cleanup of deprecated imports:**

* Removed all `ioutil` import statements from `imagepolicy.go`, `imagepolicy_test.go`, and `audit.go`. [[1]](diffhunk://#diff-cdcdfbefd001b871d1021ed12acc1a956547af51d4bd5ac2b29c4c11a5e94e71L7) [[2]](diffhunk://#diff-0b435b3dedab1dd0fce32a4344a758ae159deafc7e2d61479596c6614a3c543cL7-R7) [[3]](diffhunk://#diff-2aa4936b27d1e24a11d34cd397f6b0fd6985b3ddfab1795f3b7ff0192d1184e0L4)