### PR TITLE
NO-JIRA: scc: Remove pod prefix from error field paths

### DIFF
--- a/pkg/securitycontextconstraints/seccomp/strategy.go
+++ b/pkg/securitycontextconstraints/seccomp/strategy.go
@@ -82,7 +82,7 @@ func (s *strategy) Generate(podAnnotations map[string]string, pod *api.Pod) (str
 // of the strategy.
 func (s *strategy) ValidatePod(pod *api.Pod) field.ErrorList {
 	allErrs := field.ErrorList{}
-	podSpecFieldPath := field.NewPath("pod", "metadata", "annotations").Key(api.SeccompPodAnnotationKey)
+	podSpecFieldPath := field.NewPath("metadata", "annotations").Key(api.SeccompPodAnnotationKey)
 	podProfile := pod.Annotations[api.SeccompPodAnnotationKey]
 	// if the annotation is not set, see if the field is set and derive the corresponding annotation value
 	// We are keeping annotations for backward compatibility - in case the pod is
@@ -102,7 +102,7 @@ func (s *strategy) ValidatePod(pod *api.Pod) field.ErrorList {
 // the range of the strategy.
 func (s *strategy) ValidateContainer(pod *api.Pod, container *api.Container) field.ErrorList {
 	allErrs := field.ErrorList{}
-	fieldPath := field.NewPath("pod", "metadata", "annotations").Key(api.SeccompContainerAnnotationKeyPrefix + container.Name)
+	fieldPath := field.NewPath("metadata", "annotations").Key(api.SeccompContainerAnnotationKeyPrefix + container.Name)
 	containerProfile := profileForContainer(pod, container)
 
 	if err := s.validateProfile(fieldPath, containerProfile); err != nil {

--- a/pkg/securitycontextconstraints/seccomp/strategy_test.go
+++ b/pkg/securitycontextconstraints/seccomp/strategy_test.go
@@ -253,6 +253,24 @@ func TestValidatePod(t *testing.T) {
 	}
 }
 
+func TestValidatePod_FieldPath(t *testing.T) {
+	strategy := NewSeccompStrategy([]string{"foo"})
+	pod := &api.Pod{}
+	pod.Annotations = map[string]string{
+		api.SeccompPodAnnotationKey: "bar",
+	}
+
+	errs := strategy.ValidatePod(pod)
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(errs))
+	}
+
+	expectedField := "metadata.annotations[seccomp.security.alpha.kubernetes.io/pod]"
+	if errs[0].Field != expectedField {
+		t.Errorf("expected field path %q, got %q", expectedField, errs[0].Field)
+	}
+}
+
 func TestValidateContainer(t *testing.T) {
 	newPod := func(annotationProfile string, fieldProfile *api.SeccompProfile) *api.Pod {
 		pod := &api.Pod{
@@ -365,6 +383,28 @@ func TestValidateContainer(t *testing.T) {
 				t.Errorf("%s expected error to contain %q but it did not: %v", name, tc.expectedMsg, errs)
 			}
 		}
+	}
+}
+
+func TestValidateContainer_FieldPath(t *testing.T) {
+	strategy := NewSeccompStrategy([]string{"foo"})
+	pod := &api.Pod{
+		Spec: api.PodSpec{
+			Containers: []api.Container{{Name: "test"}},
+		},
+	}
+	pod.Annotations = map[string]string{
+		api.SeccompContainerAnnotationKeyPrefix + "test": "bar",
+	}
+
+	errs := strategy.ValidateContainer(pod, &pod.Spec.Containers[0])
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(errs))
+	}
+
+	expectedField := "metadata.annotations[container.seccomp.security.alpha.kubernetes.io/test]"
+	if errs[0].Field != expectedField {
+		t.Errorf("expected field path %q, got %q", expectedField, errs[0].Field)
 	}
 }
 

--- a/pkg/securitycontextconstraints/sysctl/mustmatchpatterns.go
+++ b/pkg/securitycontextconstraints/sysctl/mustmatchpatterns.go
@@ -166,7 +166,7 @@ func (s *mustMatchPatterns) Validate(pod *api.Pod) field.ErrorList {
 		sysctls = pod.Spec.SecurityContext.Sysctls
 	}
 
-	fieldPath := field.NewPath("pod", "spec", "securityContext").Child("sysctls")
+	fieldPath := field.NewPath("spec", "securityContext").Child("sysctls")
 
 	for i, sysctl := range sysctls {
 		switch {

--- a/pkg/securitycontextconstraints/sysctl/mustmatchpatterns_test.go
+++ b/pkg/securitycontextconstraints/sysctl/mustmatchpatterns_test.go
@@ -106,6 +106,29 @@ func TestValidate(t *testing.T) {
 	}
 }
 
+func TestValidate_FieldPath(t *testing.T) {
+	strategy := NewMustMatchPatterns([]string{"safe.sysctl"}, nil, nil)
+	pod := &api.Pod{
+		Spec: api.PodSpec{
+			SecurityContext: &api.PodSecurityContext{
+				Sysctls: []api.Sysctl{
+					{Name: "unsafe.sysctl", Value: "1"},
+				},
+			},
+		},
+	}
+
+	errs := strategy.Validate(pod)
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(errs))
+	}
+
+	expectedField := "spec.securityContext.sysctls[0]"
+	if errs[0].Field != expectedField {
+		t.Errorf("expected field path %q, got %q", expectedField, errs[0].Field)
+	}
+}
+
 func TestGetSafeSysctlAllowlist(t *testing.T) {
 	var legacySafeSysctls = []string{
 		"kernel.shm_rmid_forced",


### PR DESCRIPTION
Remove the "pod" prefix from validation error field paths. The paths
should be relative to the resource being validated and match actual
field paths in the manifest (e.g. spec.securityContext.sysctls[0])
rather than prefixing with the resource kind (pod.spec...).
    
This aligns with standard Kubernetes validation conventions.
