### PR TITLE
NO-JIRA: OWNERS: remove soltysh and add tchap

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,8 @@
 reviewers:
   - bertinatto
   - deads2k
-  - soltysh
+  - tchap
 approvers:
   - bertinatto
   - deads2k
-  - soltysh
+  - tchap


### PR DESCRIPTION
## Summary
- Remove engineer who is no longer with Red Hat from OWNERS file
- Add tchap as reviewer/approver to maintain sufficient coverage

### Removed
- soltysh (Maciej Szulik)

### Added
- tchap (Ondra Kupka)